### PR TITLE
add FindLLVM/FindClang support.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,24 +21,29 @@ if(CMAKE_SOURCE_DIR STREQUAL CMAKE_BINARY_DIR)
 endif()
 
 # Initialize input variables
-set(LLVM_SRC_DIR "" CACHE FILEPATH "LLVM source directory")
-set(LLVM_SRC_BUILD_DIR "" CACHE FILEPATH "LLVM build directory")
+set(LLVM_INCLUDE_DIR "" CACHE FILEPATH "LLVM include directory")
+set(LLVM_LIB_DIR "" CACHE FILEPATH "LLVM lib directory")
+set(CLANG_INCLUDE_DIRS "" CACHE FILEPATH "Clang include directory")
 
-if (LLVM_DEV_DIR)
-   set(LLVM_SRC_DIR ${LLVM_DEV_DIR})
-   set(LLVM_SRC_BUILD_DIR ${LLVM_DEV_DIR})
+INCLUDE(cmake/FindLLVM.cmake)
+INCLUDE(cmake/FindClang.cmake)
+
+# Require LLVM_INCLUDE_DIR
+if (LLVM_INCLUDE_DIR)
+   set(LLVM_INCLUDE_DIR ${LLVM_INCLUDE_DIR})
 else()
-   message(FATAL_ERROR "You must set LLVM_DEV_DIR (`cmake -D LLVM_DEV_DIR=$LLVM_DEV_DIR`).")
+   message(FATAL_ERROR "Could not find LLVM headers. Install LLVM headers please")
 endif()
 
-# Require LLVM_SRC_DIR
-if(NOT LLVM_SRC_DIR)
-  message(FATAL_ERROR "You must set LLVM_SRC_DIR (`cmake -D LLVM_SRC_DIR=$LLVM_SRC_DIR`).")
+# Require LLVM_LIB_DIR
+if(LLVM_LIB_DIR)
+else()
+   message(FATAL_ERROR "Could not find LLVM lib. Install LLVM lib please")
 endif()
 
-# Require LLVM_SRC_BUILD_DIR
-if(NOT LLVM_SRC_BUILD_DIR)
-  message(FATAL_ERROR "You must set LLVM_SRC_BUILD_DIR (`cmake -D LLVM_SRC_BUILD_DIR=$LLVM_SRC_BUILD_DIR`).")
+# Require CLANG_FOUND
+if(NOT CLANG_FOUND)
+   message(FATAL_ERROR "Could not find Clang headers. Install Clang please")
 endif()
 # /usr/lib/llvm-3.5/
 set( CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin )
@@ -50,8 +55,6 @@ set( CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib )
 
 # assumes for clang to be under llvm/tools/, as suggested by the clang website
 # http://clang.llvm.org/get_started.html#build
-set (CLANG_SRC_DIR  ${LLVM_SRC_DIR}/tools/clang)
-set (CLANG_BUILD_DIR ${LLVM_SRC_BUILD_DIR}/tools/clang)
 
 add_definitions (-D__STDC_LIMIT_MACROS -D__STDC_CONSTANT_MACROS)
 add_definitions (-D_GNU_SOURCE -DHAVE_CLANG_CONFIG_H)
@@ -63,12 +66,11 @@ set (CMAKE_MODULE_LINKER_FLAGS "-Wl,-flat_namespace -Wl,-undefined -Wl,suppress"
 macro(add_clang_plugin name)
    set (srcs ${ARGN})
 
-   include_directories( "${LLVM_SRC_DIR}/include"
-      "${LLVM_SRC_BUILD_DIR}/include"
-      "${CLANG_SRC_DIR}/include"
-      "${CLANG_BUILD_DIR}/include"
+   include_directories(
+      "${LLVM_INLCUDE_DIR}/"
+      "${CLANG_INCLUDE_DIRS}"
       "${CMAKE_CURRENT_SOURCE_DIR}/src")
-   link_directories( "${LLVM_BUILD_DIR}/lib" )
+   link_directories( "${LLVM_LIB_DIR}/" )
 
    add_library( ${name} SHARED ${srcs} )
 

--- a/cmake/FindClang.cmake
+++ b/cmake/FindClang.cmake
@@ -1,0 +1,61 @@
+# Detect CLANG
+if (NOT LLVM_INCLUDE_DIR OR NOT LLVM_LIB_DIR)
+   message(FATAL_ERROR "No LLVM and Clang support requires LLVM")
+else (NOT LLVM_INCLUDE_DIR OR NOT LLVM_LIB_DIR)
+
+MACRO(FIND_AND_ADD_CLANG_LIB _libname_)
+find_library(CLANG_${_libname_}_LIB ${_libname_} ${LLVM_LIB_DIR} ${CLANG_LIB_DIR})
+if (CLANG_${_libname_}_LIB)
+   set(CLANG_LIBS ${CLANG_LIBS} ${CLANG_${_libname_}_LIB})
+endif(CLANG_${_libname_}_LIB)
+ENDMACRO(FIND_AND_ADD_CLANG_LIB)
+
+set(CLANG_INCLUDE_DIRS ${CLANG_INCLUDE_DIRS} ${LLVM_INCLUDE_DIR})
+set(CLANG_INCLUDE_DIRS ${CLANG_INCLUDE_DIRS} ${CLANG_INCLUDE_DIR})
+
+FIND_AND_ADD_CLANG_LIB(clangFrontend)
+FIND_AND_ADD_CLANG_LIB(clangDriver)
+FIND_AND_ADD_CLANG_LIB(clangCodeGen)
+FIND_AND_ADD_CLANG_LIB(clangSema)
+FIND_AND_ADD_CLANG_LIB(clangChecker)
+FIND_AND_ADD_CLANG_LIB(clangAnalysis)
+FIND_AND_ADD_CLANG_LIB(clangRewrite)
+FIND_AND_ADD_CLANG_LIB(clangAST)
+FIND_AND_ADD_CLANG_LIB(clangParse)
+FIND_AND_ADD_CLANG_LIB(clangLex)
+FIND_AND_ADD_CLANG_LIB(clangBasic)
+FIND_AND_ADD_CLANG_LIB(clangARCMigrate)
+FIND_AND_ADD_CLANG_LIB(clangEdit)
+FIND_AND_ADD_CLANG_LIB(clangFrontendTool)
+FIND_AND_ADD_CLANG_LIB(clangRewrite)
+FIND_AND_ADD_CLANG_LIB(clangSerialization)
+FIND_AND_ADD_CLANG_LIB(clangTooling)
+FIND_AND_ADD_CLANG_LIB(clangStaticAnalyzerCheckers)
+FIND_AND_ADD_CLANG_LIB(clangStaticAnalyzerCore)
+FIND_AND_ADD_CLANG_LIB(clangStaticAnalyzerFrontend)
+FIND_AND_ADD_CLANG_LIB(clangSema)
+FIND_AND_ADD_CLANG_LIB(clangRewriteCore)
+# clang 3.7
+FIND_AND_ADD_CLANG_LIB(clangRewriteFrontend)
+FIND_AND_ADD_CLANG_LIB(clangASTMatchers)
+FIND_AND_ADD_CLANG_LIB(clangToolingCore)
+
+
+
+
+
+MESSAGE(STATUS "Clang libs: " ${CLANG_LIBS})
+
+if(CLANG_LIBS)
+  set(CLANG_FOUND TRUE)
+endif(CLANG_LIBS)
+
+if(CLANG_FOUND)
+  message(STATUS "Found Clang: ${CLANG_INCLUDE_DIRS}")
+else(CLANG_FOUND)
+  if(CLANG_FIND_REQUIRED)
+    message(FATAL_ERROR "Could NOT find Clang")
+  endif(CLANG_FIND_REQUIRED)
+endif(CLANG_FOUND)
+
+endif (NOT LLVM_INCLUDE_DIR OR NOT LLVM_LIB_DIR)

--- a/cmake/FindLLVM.cmake
+++ b/cmake/FindLLVM.cmake
@@ -1,0 +1,132 @@
+# Detect LLVM and set various variable to link against the different component of LLVM
+#
+# NOTE: This is a modified version of the module originally found in the OpenGTL project
+# at www.opengtl.org
+#
+# LLVM_BIN_DIR : directory with LLVM binaries
+# LLVM_LIB_DIR : directory with LLVM library
+# LLVM_INCLUDE_DIR : directory with LLVM include
+#
+# LLVM_COMPILE_FLAGS : compile flags needed to build a program using LLVM headers
+# LLVM_LDFLAGS : ldflags needed to link
+# LLVM_LIBS_CORE : ldflags needed to link against a LLVM core library
+# LLVM_LIBS_JIT : ldflags needed to link against a LLVM JIT
+# LLVM_LIBS_JIT_OBJECTS : objects you need to add to your source when using LLVM JIT
+
+if (MSVC)
+  set(LLVM_ROOT "C:/Program Files/LLVM")
+  if (NOT IS_DIRECTORY ${LLVM_ROOT})
+    message(FATAL_ERROR "Could NOT find LLVM")
+  endif ()
+
+  message(STATUS "Found LLVM: ${LLVM_ROOT}")
+  set(LLVM_BIN_DIR ${LLVM_ROOT}/bin)
+  set(LLVM_LIB_DIR ${LLVM_ROOT}/lib)
+  set(LLVM_INCLUDE_DIR ${LLVM_ROOT}/include)
+
+  set(LLVM_COMPILE_FLAGS "")
+  set(LLVM_LDFLAGS "")
+  set(LLVM_LIBS_CORE LLVMLinker LLVMArchive LLVMBitWriter LLVMBitReader LLVMInstrumentation LLVMScalarOpts LLVMipo LLVMTransformUtils LLVMipa LLVMAnalysis LLVMTarget LLVMMC LLVMCore LLVMSupport LLVMSystem)
+  set(LLVM_LIBS_JIT LLVMX86AsmParser LLVMX86AsmPrinter LLVMX86CodeGen LLVMSelectionDAG LLVMAsmPrinter LLVMX86Info LLVMJIT LLVMExecutionEngine LLVMCodeGen LLVMScalarOpts LLVMTransformUtils LLVMipa LLVMAnalysis LLVMTarget LLVMMC LLVMCore LLVMSupport LLVMSystem)
+  set(LLVM_LIBS_JIT_OBJECTS "")
+endif (MSVC)
+
+if (LLVM_INCLUDE_DIR)
+  set(LLVM_FOUND TRUE)
+else (LLVM_INCLUDE_DIR)
+
+  find_program(LLVM_CONFIG_EXECUTABLE
+    NAMES llvm-config-3.3 llvm-config
+    )
+
+  if(LLVM_CONFIG_EXECUTABLE)
+    MESSAGE(STATUS "LLVM llvm-config found at: ${LLVM_CONFIG_EXECUTABLE}")
+  else(LLVM_CONFIG_EXECUTABLE)
+    MESSAGE(FATAL_ERROR "Could NOT find LLVM")
+  endif(LLVM_CONFIG_EXECUTABLE)
+
+  MACRO(FIND_LLVM_LIBS LLVM_CONFIG_EXECUTABLE _libname_ LIB_VAR OBJECT_VAR)
+    exec_program( ${LLVM_CONFIG_EXECUTABLE} ARGS --libs ${_libname_}  OUTPUT_VARIABLE ${LIB_VAR} )
+    STRING(REGEX MATCHALL "[^ ]*[.]o[ $]"  ${OBJECT_VAR} ${${LIB_VAR}})
+    SEPARATE_ARGUMENTS(${OBJECT_VAR})
+    STRING(REGEX REPLACE "[^ ]*[.]o[ $]" ""  ${LIB_VAR} ${${LIB_VAR}})
+  ENDMACRO(FIND_LLVM_LIBS)
+  
+  
+  # this function borrowed from PlPlot, Copyright (C) 2006  Alan W. Irwin
+  function(TRANSFORM_VERSION numerical_result version)
+    # internal_version ignores everything in version after any character that
+    # is not 0-9 or ".".  This should take care of the case when there is
+    # some non-numerical data in the patch version.
+    #message(STATUS "DEBUG: version = ${version}")
+    string(REGEX REPLACE "^([0-9.]+).*$" "\\1" internal_version ${version})
+    
+    # internal_version is normally a period-delimited triplet string of the form
+    # "major.minor.patch", but patch and/or minor could be missing.
+    # Transform internal_version into a numerical result that can be compared.
+    string(REGEX REPLACE "^([0-9]*).+$" "\\1" major ${internal_version})
+    string(REGEX REPLACE "^[0-9]*\\.([0-9]*).*$" "\\1" minor ${internal_version})
+    #string(REGEX REPLACE "^[0-9]*\\.[0-9]*\\.([0-9]*)$" "\\1" patch ${internal_version})
+    
+    #if(NOT patch MATCHES "[0-9]+")
+    #  set(patch 0)
+    #endif(NOT patch MATCHES "[0-9]+")
+    set(patch 0)
+    
+    if(NOT minor MATCHES "[0-9]+")
+      set(minor 0)
+    endif(NOT minor MATCHES "[0-9]+")
+    
+    if(NOT major MATCHES "[0-9]+")
+      set(major 0)
+    endif(NOT major MATCHES "[0-9]+")
+    #message(STATUS "DEBUG: internal_version = ${internal_version}")
+    #message(STATUS "DEBUG: major = ${major}")
+    #message(STATUS "DEBUG: minor= ${minor}")
+    #message(STATUS "DEBUG: patch = ${patch}")
+    math(EXPR internal_numerical_result
+      #"${major}*1000000 + ${minor}*1000 + ${patch}"
+      "${major}*1000000 + ${minor}*1000"
+      )
+    #message(STATUS "DEBUG: ${numerical_result} = ${internal_numerical_result}")
+    set(${numerical_result} ${internal_numerical_result} PARENT_SCOPE)
+  endfunction(TRANSFORM_VERSION)
+  
+  
+  exec_program(${LLVM_CONFIG_EXECUTABLE} ARGS --version OUTPUT_VARIABLE LLVM_STRING_VERSION )
+  MESSAGE(STATUS "LLVM version: " ${LLVM_STRING_VERSION})
+  transform_version(LLVM_VERSION ${LLVM_STRING_VERSION})
+  
+  exec_program(${LLVM_CONFIG_EXECUTABLE} ARGS --bindir OUTPUT_VARIABLE LLVM_BIN_DIR )
+  exec_program(${LLVM_CONFIG_EXECUTABLE} ARGS --libdir OUTPUT_VARIABLE LLVM_LIB_DIR )
+  #MESSAGE(STATUS "LLVM lib dir: " ${LLVM_LIB_DIR})
+  exec_program(${LLVM_CONFIG_EXECUTABLE} ARGS --includedir OUTPUT_VARIABLE LLVM_INCLUDE_DIR )
+  
+  
+  exec_program(${LLVM_CONFIG_EXECUTABLE} ARGS --cxxflags  OUTPUT_VARIABLE LLVM_COMPILE_FLAGS )
+  MESSAGE(STATUS "LLVM CXX flags: " ${LLVM_COMPILE_FLAGS})
+  exec_program(${LLVM_CONFIG_EXECUTABLE} ARGS --ldflags   OUTPUT_VARIABLE LLVM_LDFLAGS )
+  MESSAGE(STATUS "LLVM LD flags: " ${LLVM_LDFLAGS})
+  exec_program(${LLVM_CONFIG_EXECUTABLE} ARGS --libs core ipa ipo instrumentation bitreader bitwriter linker OUTPUT_VARIABLE LLVM_LIBS_CORE )
+  MESSAGE(STATUS "LLVM core libs: " ${LLVM_LIBS_CORE})
+  IF(APPLE AND UNIVERSAL)
+    FIND_LLVM_LIBS( ${LLVM_CONFIG_EXECUTABLE} "jit native x86 PowerPC ARM" LLVM_LIBS_JIT LLVM_LIBS_JIT_OBJECTS )
+  ELSE(APPLE AND UNIVERSAL)
+    FIND_LLVM_LIBS( ${LLVM_CONFIG_EXECUTABLE} "jit native" LLVM_LIBS_JIT LLVM_LIBS_JIT_OBJECTS )
+  ENDIF(APPLE AND UNIVERSAL)
+  MESSAGE(STATUS "LLVM JIT libs: " ${LLVM_LIBS_JIT})
+  MESSAGE(STATUS "LLVM JIT objs: " ${LLVM_LIBS_JIT_OBJECTS})
+  
+  if(LLVM_INCLUDE_DIR)
+    set(LLVM_FOUND TRUE)
+  endif(LLVM_INCLUDE_DIR)
+  
+  if(LLVM_FOUND)
+    message(STATUS "Found LLVM: ${LLVM_INCLUDE_DIR}")
+  else(LLVM_FOUND)
+    if(LLVM_FIND_REQUIRED)
+      message(FATAL_ERROR "Could NOT find LLVM")
+    endif(LLVM_FIND_REQUIRED)
+  endif(LLVM_FOUND)
+
+endif (LLVM_INCLUDE_DIR)


### PR DESCRIPTION
Add FindLLVM/FindClang module into build infrastructure, cmake will automagically find llvm/clang's include/libs directory without typing -DLLVM_DEV_DIR.
resolve #7 