### PR TITLE
Add White / Black List Machanism for Path matching

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -123,6 +123,7 @@ add_clang_plugin(libSas
    src/BlackWhiteListCheckerDisabler.cpp
    # New Structure
    src/CodingConventions/General/UsingNamespace.cpp
+   src/CodingConventions/General/StdPrintoutsChecker.cpp
    src/CodingConventions/ROOT/RN3Checker.cpp
    src/CodingConventions/ROOT/RN4Checker.cpp
    src/CodingConventions/ROOT/RN6Checker.cpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -57,6 +57,17 @@ set( CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin )
 set( CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib )
 set( CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib )
 
+# Find yaml-cpp
+include(cmake/FindYamlCpp.cmake)
+# Yaml-cpp is based on boost, find boost
+include(cmake/FindBoost.cmake)
+
+if(NOT YAMLCPP_FOUND)
+  message(FATAL_ERROR "Could not find libyaml-cpp")
+endif()
+if(NOT Boost_FOUND)
+  message(FATAL_ERROR "Could not find boost, Black/White List Filter may not work!")
+endif()
 
 # the rest should work automatically
 
@@ -66,7 +77,7 @@ set( CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib )
 add_definitions (-D__STDC_LIMIT_MACROS -D__STDC_CONSTANT_MACROS)
 add_definitions (-D_GNU_SOURCE -DHAVE_CLANG_CONFIG_H)
 
-set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -fno-common -Woverloaded-virtual -Wcast-qual -fno-strict-aliasing -pedantic -Wno-long-long -Wall -W -Wno-unused-parameter -Wwrite-strings -fno-exceptions -fno-rtti -O3")
+set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -fno-common -Woverloaded-virtual -Wcast-qual -fno-strict-aliasing -pedantic -Wno-long-long -Wall -W -Wno-unused-parameter -Wwrite-strings -fexceptions -fno-rtti -O3")
 
 set (CMAKE_MODULE_LINKER_FLAGS "-Wl,-flat_namespace -Wl,-undefined -Wl,suppress")
 
@@ -76,7 +87,8 @@ macro(add_clang_plugin name)
    include_directories(
       "${LLVM_INLCUDE_DIR}/"
       "${CLANG_INCLUDE_DIRS}"
-      "${CMAKE_CURRENT_SOURCE_DIR}/src")
+      "${CMAKE_CURRENT_SOURCE_DIR}/src"
+      "${YAMLCPP_INCLUDE_DIR}")
    link_directories( "${LLVM_LIB_DIR}/" )
 
    add_library( ${name} SHARED ${srcs} )
@@ -97,6 +109,7 @@ endmacro(add_clang_plugin)
 
 set (USER_LIBS
    pthread
+   ${YAMLCPP_LIBRARY}
 )
 
 # Add new checkers to the plugin by adding their source files as arguments to
@@ -107,6 +120,7 @@ add_clang_plugin(libSas
 #    src/ClassDumper.cpp
    src/CatchAll.cpp
    src/CheckerDisabler.cpp
+   src/BlackWhiteListCheckerDisabler.cpp
    # New Structure
    src/CodingConventions/General/UsingNamespace.cpp
    src/CodingConventions/ROOT/RN3Checker.cpp

--- a/CTestConfig.cmake
+++ b/CTestConfig.cmake
@@ -4,23 +4,33 @@ set(CTEST_SOURCE_DIRECTORY "$ENV{CMAKE_SOURCE_DIR}")
 set(CTEST_BINARY_DIRECTORY "$ENV{CMAKE_BINARY_DIR}")
 set(CTEST_COMMAND "ctest")
 
-macro(add_sas_test TEST_NAME TEST_SOURCE)
+macro(add_sas_test_generic TEST_NAME TEST_SOURCE TEST_WORKING_DIRECTORY CONFIGURATION_YAML)
    set(SAS_TEST_SCRIPT "${CMAKE_SOURCE_DIR}/scripts/test.py")
    set(SAS_CLANG "${CMAKE_BINARY_DIR}/scripts/clang")
    set(SAS_CLANGXX "${CMAKE_BINARY_DIR}/scripts/clang++")
    set(SAS_BINARY "${CMAKE_BINARY_DIR}/lib/libSas.so")
 
    # By default use the name of the test
-   set(TEST_ENABLED_CHECKERS ${TEST_NAME})
+   if(${TEST_NAME} MATCHES "^bwlist")
+     set(TEST_ENABLED_CHECKERS "sas.CodingConventions.ROOT")
+   else()
+     set(TEST_ENABLED_CHECKERS ${TEST_NAME})
+   endif()
 
-   set(FULL_TEST_SOURCE "${CMAKE_SOURCE_DIR}/test/${TEST_SOURCE}")
-   set(FULL_TEST_REF "${CMAKE_SOURCE_DIR}/test/${TEST_SOURCE}")
-   string(REPLACE ".cpp" ".ref" FULL_TEST_REF ${FULL_TEST_SOURCE})
-
+   set(FULL_TEST_REF "${CMAKE_SOURCE_DIR}/test/${TEST_WORKING_DIRECTORY}${TEST_SOURCE}")
+   string(REPLACE ".cpp" ".ref" FULL_TEST_REF ${FULL_TEST_REF})
    add_test(NAME "${TEST_NAME}"
-            COMMAND "python" "${SAS_TEST_SCRIPT}" "${SAS_CLANGXX}" "${FULL_TEST_SOURCE}" "${SAS_BINARY}" "${TEST_ENABLED_CHECKERS}" "${FULL_TEST_REF}"
-            WORKING_DIRECTORY "${CMAKE_BINARY_DIR}/Testing")
-endmacro(add_sas_test)
+     COMMAND "python" "${SAS_TEST_SCRIPT}" "${SAS_CLANGXX}" "${TEST_SOURCE}" "${SAS_BINARY}" "${TEST_ENABLED_CHECKERS}" "${FULL_TEST_REF}" "${CONFIGURATION_YAML}"
+     WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}/test/${TEST_WORKING_DIRECTORY}")
+ endmacro(add_sas_test_generic)
+
+ macro(add_sas_test TEST_NAME TEST_SOURCE)
+   add_sas_test_generic("${TEST_NAME}" "${TEST_SOURCE}" "" "")
+ endmacro(add_sas_test)
+
+macro(add_sas_test_wd TEST_NAME TEST_SOURCE TEST_WORKING_DIRECTORY)
+   add_sas_test_generic("${TEST_NAME}" "${TEST_SOURCE}" "${TEST_WORKING_DIRECTORY}" "")
+endmacro(add_sas_test_wd)
 
 enable_testing()
 
@@ -42,5 +52,17 @@ add_sas_test("sas.ThreadSafety.MutableMember" "ThreadSafety/mutable_member.cpp")
 
 add_sas_test("sas.Performance.ArgSizeChecker"    "Performance/arg_size.cpp")
 add_sas_test("sas.Performance.FiniteMathChecker" "Performance/finite_math.cpp")
+
+add_sas_test_wd("bwlist.filepath.blacklist.match"  "BlackList/match.cpp" "BWList/FilePath/")
+add_sas_test_wd("bwlist.filepath.blacklist.unmatch"  "BlackList/unmatch.cpp" "BWList/FilePath/")
+add_sas_test_wd("bwlist.filepath.whitelist.match"  "WhiteList/match.cpp" "BWList/FilePath/")
+add_sas_test_wd("bwlist.filepath.whitelist.unmatch"  "WhiteList/unmatch.cpp" "BWList/FilePath/")
+add_sas_test_wd("bwlist.namespace.blacklist" "BlackList/match.cpp" "BWList/Namespace/")
+add_sas_test_wd("bwlist.namespace.whitelist" "WhiteList/match.cpp" "BWList/Namespace/")
+add_sas_test_wd("bwlist.class.blacklist" "BlackList/match.cpp" "BWList/Class/")
+add_sas_test_wd("bwlist.class.whitelist" "WhiteList/match.cpp" "BWList/Class/")
+add_sas_test_wd("bwlist.struct.blacklist" "BlackList/match.cpp" "BWList/Struct/")
+add_sas_test_wd("bwlist.struct.whitelist" "WhiteList/match.cpp" "BWList/Struct/")
+add_sas_test_generic("bwlist.locate_yaml_by_env" "match.cpp" "BWList/Misc/" "configuration.yaml")
 
 add_sas_test("sas.Example.Varname"  "Example/varname.cpp")

--- a/CTestConfig.cmake
+++ b/CTestConfig.cmake
@@ -43,6 +43,7 @@ add_sas_test("sas.CodingConventions.ROOT.RN11"                         "CodingCo
 add_sas_test("sas.CodingConventions.ROOT.RN12"                         "CodingConventions/ROOT/RN12.cpp")
 add_sas_test("sas.CodingConventions.ROOT.PtrCastWin"                   "CodingConventions/ROOT/ptr_cast_win.cpp")
 add_sas_test("sas.CodingConventions.General.NoUsingNamespaceInHeaders" "CodingConventions/General/using_namespace.cpp")
+add_sas_test("sas.CodingConventions.General.StdPrintouts" "CodingConventions/General/std_printouts.cpp")
 
 add_sas_test("sas.ThreadSafety.ConstCastAway" "ThreadSafety/const_cast_away.cpp")
 add_sas_test("sas.ThreadSafety.ConstCast"     "ThreadSafety/const_cast.cpp")

--- a/cmake/FindBoost.cmake
+++ b/cmake/FindBoost.cmake
@@ -1,0 +1,1296 @@
+#.rst:
+# FindBoost
+# ---------
+#
+# Find Boost include dirs and libraries
+#
+# Use this module by invoking find_package with the form::
+#
+#   find_package(Boost
+#     [version] [EXACT]      # Minimum or EXACT version e.g. 1.36.0
+#     [REQUIRED]             # Fail with error if Boost is not found
+#     [COMPONENTS <libs>...] # Boost libraries by their canonical name
+#     )                      # e.g. "date_time" for "libboost_date_time"
+#
+# This module finds headers and requested component libraries OR a CMake
+# package configuration file provided by a "Boost CMake" build.  For the
+# latter case skip to the "Boost CMake" section below.  For the former
+# case results are reported in variables::
+#
+#   Boost_FOUND            - True if headers and requested libraries were found
+#   Boost_INCLUDE_DIRS     - Boost include directories
+#   Boost_LIBRARY_DIRS     - Link directories for Boost libraries
+#   Boost_LIBRARIES        - Boost component libraries to be linked
+#   Boost_<C>_FOUND        - True if component <C> was found (<C> is upper-case)
+#   Boost_<C>_LIBRARY      - Libraries to link for component <C> (may include
+#                            target_link_libraries debug/optimized keywords)
+#   Boost_VERSION          - BOOST_VERSION value from boost/version.hpp
+#   Boost_LIB_VERSION      - Version string appended to library filenames
+#   Boost_MAJOR_VERSION    - Boost major version number (X in X.y.z)
+#   Boost_MINOR_VERSION    - Boost minor version number (Y in x.Y.z)
+#   Boost_SUBMINOR_VERSION - Boost subminor version number (Z in x.y.Z)
+#   Boost_LIB_DIAGNOSTIC_DEFINITIONS (Windows)
+#                          - Pass to add_definitions() to have diagnostic
+#                            information about Boost's automatic linking
+#                            displayed during compilation
+#
+# This module reads hints about search locations from variables::
+#
+#   BOOST_ROOT             - Preferred installation prefix
+#    (or BOOSTROOT)
+#   BOOST_INCLUDEDIR       - Preferred include directory e.g. <prefix>/include
+#   BOOST_LIBRARYDIR       - Preferred library directory e.g. <prefix>/lib
+#   Boost_NO_SYSTEM_PATHS  - Set to ON to disable searching in locations not
+#                            specified by these hint variables. Default is OFF.
+#   Boost_ADDITIONAL_VERSIONS
+#                          - List of Boost versions not known to this module
+#                            (Boost install locations may contain the version)
+#
+# and saves search results persistently in CMake cache entries::
+#
+#   Boost_INCLUDE_DIR         - Directory containing Boost headers
+#   Boost_LIBRARY_DIR_RELEASE - Directory containing release Boost libraries
+#   Boost_LIBRARY_DIR_DEBUG   - Directory containing debug Boost libraries
+#   Boost_<C>_LIBRARY_DEBUG   - Component <C> library debug variant
+#   Boost_<C>_LIBRARY_RELEASE - Component <C> library release variant
+#
+# Users may set these hints or results as cache entries.  Projects
+# should not read these entries directly but instead use the above
+# result variables.  Note that some hint names start in upper-case
+# "BOOST".  One may specify these as environment variables if they are
+# not specified as CMake variables or cache entries.
+#
+# This module first searches for the Boost header files using the above
+# hint variables (excluding BOOST_LIBRARYDIR) and saves the result in
+# Boost_INCLUDE_DIR.  Then it searches for requested component libraries
+# using the above hints (excluding BOOST_INCLUDEDIR and
+# Boost_ADDITIONAL_VERSIONS), "lib" directories near Boost_INCLUDE_DIR,
+# and the library name configuration settings below.  It saves the
+# library directories in Boost_LIBRARY_DIR_DEBUG and
+# Boost_LIBRARY_DIR_RELEASE and individual library
+# locations in Boost_<C>_LIBRARY_DEBUG and Boost_<C>_LIBRARY_RELEASE.
+# When one changes settings used by previous searches in the same build
+# tree (excluding environment variables) this module discards previous
+# search results affected by the changes and searches again.
+#
+# Boost libraries come in many variants encoded in their file name.
+# Users or projects may tell this module which variant to find by
+# setting variables::
+#
+#   Boost_USE_MULTITHREADED  - Set to OFF to use the non-multithreaded
+#                              libraries ('mt' tag).  Default is ON.
+#   Boost_USE_STATIC_LIBS    - Set to ON to force the use of the static
+#                              libraries.  Default is OFF.
+#   Boost_USE_STATIC_RUNTIME - Set to ON or OFF to specify whether to use
+#                              libraries linked statically to the C++ runtime
+#                              ('s' tag).  Default is platform dependent.
+#   Boost_USE_DEBUG_RUNTIME  - Set to ON or OFF to specify whether to use
+#                              libraries linked to the MS debug C++ runtime
+#                              ('g' tag).  Default is ON.
+#   Boost_USE_DEBUG_PYTHON   - Set to ON to use libraries compiled with a
+#                              debug Python build ('y' tag). Default is OFF.
+#   Boost_USE_STLPORT        - Set to ON to use libraries compiled with
+#                              STLPort ('p' tag).  Default is OFF.
+#   Boost_USE_STLPORT_DEPRECATED_NATIVE_IOSTREAMS
+#                            - Set to ON to use libraries compiled with
+#                              STLPort deprecated "native iostreams"
+#                              ('n' tag).  Default is OFF.
+#   Boost_COMPILER           - Set to the compiler-specific library suffix
+#                              (e.g. "-gcc43").  Default is auto-computed
+#                              for the C++ compiler in use.
+#   Boost_THREADAPI          - Suffix for "thread" component library name,
+#                              such as "pthread" or "win32".  Names with
+#                              and without this suffix will both be tried.
+#   Boost_NAMESPACE          - Alternate namespace used to build boost with
+#                              e.g. if set to "myboost", will search for
+#                              myboost_thread instead of boost_thread.
+#
+# Other variables one may set to control this module are::
+#
+#   Boost_DEBUG              - Set to ON to enable debug output from FindBoost.
+#                              Please enable this before filing any bug report.
+#   Boost_DETAILED_FAILURE_MSG
+#                            - Set to ON to add detailed information to the
+#                              failure message even when the REQUIRED option
+#                              is not given to the find_package call.
+#   Boost_REALPATH           - Set to ON to resolve symlinks for discovered
+#                              libraries to assist with packaging.  For example,
+#                              the "system" component library may be resolved to
+#                              "/usr/lib/libboost_system.so.1.42.0" instead of
+#                              "/usr/lib/libboost_system.so".  This does not
+#                              affect linking and should not be enabled unless
+#                              the user needs this information.
+#   Boost_LIBRARY_DIR        - Default value for Boost_LIBRARY_DIR_RELEASE and
+#                              Boost_LIBRARY_DIR_DEBUG.
+#
+# On Visual Studio and Borland compilers Boost headers request automatic
+# linking to corresponding libraries.  This requires matching libraries
+# to be linked explicitly or available in the link library search path.
+# In this case setting Boost_USE_STATIC_LIBS to OFF may not achieve
+# dynamic linking.  Boost automatic linking typically requests static
+# libraries with a few exceptions (such as Boost.Python).  Use::
+#
+#   add_definitions(${Boost_LIB_DIAGNOSTIC_DEFINITIONS})
+#
+# to ask Boost to report information about automatic linking requests.
+#
+# Example to find Boost headers only::
+#
+#   find_package(Boost 1.36.0)
+#   if(Boost_FOUND)
+#     include_directories(${Boost_INCLUDE_DIRS})
+#     add_executable(foo foo.cc)
+#   endif()
+#
+# Example to find Boost headers and some *static* libraries::
+#
+#   set(Boost_USE_STATIC_LIBS        ON) # only find static libs
+#   set(Boost_USE_MULTITHREADED      ON)
+#   set(Boost_USE_STATIC_RUNTIME    OFF)
+#   find_package(Boost 1.36.0 COMPONENTS date_time filesystem system ...)
+#   if(Boost_FOUND)
+#     include_directories(${Boost_INCLUDE_DIRS})
+#     add_executable(foo foo.cc)
+#     target_link_libraries(foo ${Boost_LIBRARIES})
+#   endif()
+#
+# Boost CMake
+# ^^^^^^^^^^^
+#
+# If Boost was built using the boost-cmake project it provides a package
+# configuration file for use with find_package's Config mode.  This
+# module looks for the package configuration file called
+# BoostConfig.cmake or boost-config.cmake and stores the result in cache
+# entry "Boost_DIR".  If found, the package configuration file is loaded
+# and this module returns with no further action.  See documentation of
+# the Boost CMake package configuration for details on what it provides.
+#
+# Set Boost_NO_BOOST_CMAKE to ON to disable the search for boost-cmake.
+
+#=============================================================================
+# Copyright 2006-2012 Kitware, Inc.
+# Copyright 2006-2008 Andreas Schneider <mail@cynapses.org>
+# Copyright 2007      Wengo
+# Copyright 2007      Mike Jackson
+# Copyright 2008      Andreas Pakulat <apaku@gmx.de>
+# Copyright 2008-2012 Philip Lowman <philip@yhbt.com>
+#
+# Distributed under the OSI-approved BSD License (the "License");
+# see accompanying file Copyright.txt for details.
+#
+# This software is distributed WITHOUT ANY WARRANTY; without even the
+# implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+# See the License for more information.
+#=============================================================================
+# (To distribute this file outside of CMake, substitute the full
+#  License text for the above reference.)
+
+
+#-------------------------------------------------------------------------------
+# Before we go searching, check whether boost-cmake is available, unless the
+# user specifically asked NOT to search for boost-cmake.
+#
+# If Boost_DIR is set, this behaves as any find_package call would. If not,
+# it looks at BOOST_ROOT and BOOSTROOT to find Boost.
+#
+if (NOT Boost_NO_BOOST_CMAKE)
+  # If Boost_DIR is not set, look for BOOSTROOT and BOOST_ROOT as alternatives,
+  # since these are more conventional for Boost.
+  if ("$ENV{Boost_DIR}" STREQUAL "")
+    if (NOT "$ENV{BOOST_ROOT}" STREQUAL "")
+      set(ENV{Boost_DIR} $ENV{BOOST_ROOT})
+    elseif (NOT "$ENV{BOOSTROOT}" STREQUAL "")
+      set(ENV{Boost_DIR} $ENV{BOOSTROOT})
+    endif()
+  endif()
+
+  # Do the same find_package call but look specifically for the CMake version.
+  # Note that args are passed in the Boost_FIND_xxxxx variables, so there is no
+  # need to delegate them to this find_package call.
+  find_package(Boost QUIET NO_MODULE)
+  mark_as_advanced(Boost_DIR)
+
+  # If we found boost-cmake, then we're done.  Print out what we found.
+  # Otherwise let the rest of the module try to find it.
+  if (Boost_FOUND)
+    message("Boost ${Boost_FIND_VERSION} found.")
+    if (Boost_FIND_COMPONENTS)
+      message("Found Boost components:")
+      message("   ${Boost_FIND_COMPONENTS}")
+    endif()
+    return()
+  endif()
+endif()
+
+
+#-------------------------------------------------------------------------------
+#  FindBoost functions & macros
+#
+
+############################################
+#
+# Check the existence of the libraries.
+#
+############################################
+# This macro was taken directly from the FindQt4.cmake file that is included
+# with the CMake distribution. This is NOT my work. All work was done by the
+# original authors of the FindQt4.cmake file. Only minor modifications were
+# made to remove references to Qt and make this file more generally applicable
+# And ELSE/ENDIF pairs were removed for readability.
+#########################################################################
+
+macro(_Boost_ADJUST_LIB_VARS basename)
+  if(Boost_INCLUDE_DIR )
+    if(Boost_${basename}_LIBRARY_DEBUG AND Boost_${basename}_LIBRARY_RELEASE)
+      # if the generator supports configuration types then set
+      # optimized and debug libraries, or if the CMAKE_BUILD_TYPE has a value
+      if(CMAKE_CONFIGURATION_TYPES OR CMAKE_BUILD_TYPE)
+        set(Boost_${basename}_LIBRARY optimized ${Boost_${basename}_LIBRARY_RELEASE} debug ${Boost_${basename}_LIBRARY_DEBUG})
+      else()
+        # if there are no configuration types and CMAKE_BUILD_TYPE has no value
+        # then just use the release libraries
+        set(Boost_${basename}_LIBRARY ${Boost_${basename}_LIBRARY_RELEASE} )
+      endif()
+      # FIXME: This probably should be set for both cases
+      set(Boost_${basename}_LIBRARIES optimized ${Boost_${basename}_LIBRARY_RELEASE} debug ${Boost_${basename}_LIBRARY_DEBUG})
+    endif()
+
+    # if only the release version was found, set the debug variable also to the release version
+    if(Boost_${basename}_LIBRARY_RELEASE AND NOT Boost_${basename}_LIBRARY_DEBUG)
+      set(Boost_${basename}_LIBRARY_DEBUG ${Boost_${basename}_LIBRARY_RELEASE})
+      set(Boost_${basename}_LIBRARY       ${Boost_${basename}_LIBRARY_RELEASE})
+      set(Boost_${basename}_LIBRARIES     ${Boost_${basename}_LIBRARY_RELEASE})
+    endif()
+
+    # if only the debug version was found, set the release variable also to the debug version
+    if(Boost_${basename}_LIBRARY_DEBUG AND NOT Boost_${basename}_LIBRARY_RELEASE)
+      set(Boost_${basename}_LIBRARY_RELEASE ${Boost_${basename}_LIBRARY_DEBUG})
+      set(Boost_${basename}_LIBRARY         ${Boost_${basename}_LIBRARY_DEBUG})
+      set(Boost_${basename}_LIBRARIES       ${Boost_${basename}_LIBRARY_DEBUG})
+    endif()
+
+    # If the debug & release library ends up being the same, omit the keywords
+    if(${Boost_${basename}_LIBRARY_RELEASE} STREQUAL ${Boost_${basename}_LIBRARY_DEBUG})
+      set(Boost_${basename}_LIBRARY   ${Boost_${basename}_LIBRARY_RELEASE} )
+      set(Boost_${basename}_LIBRARIES ${Boost_${basename}_LIBRARY_RELEASE} )
+    endif()
+
+    if(Boost_${basename}_LIBRARY)
+      set(Boost_${basename}_FOUND ON)
+    endif()
+
+  endif()
+  # Make variables changeable to the advanced user
+  mark_as_advanced(
+      Boost_${basename}_LIBRARY_RELEASE
+      Boost_${basename}_LIBRARY_DEBUG
+  )
+endmacro()
+
+# Detect changes in used variables.
+# Compares the current variable value with the last one.
+# In short form:
+# v != v_LAST                      -> CHANGED = 1
+# v is defined, v_LAST not         -> CHANGED = 1
+# v is not defined, but v_LAST is  -> CHANGED = 1
+# otherwise                        -> CHANGED = 0
+# CHANGED is returned in variable named ${changed_var}
+macro(_Boost_CHANGE_DETECT changed_var)
+  set(${changed_var} 0)
+  foreach(v ${ARGN})
+    if(DEFINED _Boost_COMPONENTS_SEARCHED)
+      if(${v})
+        if(_${v}_LAST)
+          string(COMPARE NOTEQUAL "${${v}}" "${_${v}_LAST}" _${v}_CHANGED)
+        else()
+          set(_${v}_CHANGED 1)
+        endif()
+      elseif(_${v}_LAST)
+        set(_${v}_CHANGED 1)
+      endif()
+      if(_${v}_CHANGED)
+        set(${changed_var} 1)
+      endif()
+    else()
+      set(_${v}_CHANGED 0)
+    endif()
+  endforeach()
+endmacro()
+
+#
+# Find the given library (var).
+# Use 'build_type' to support different lib paths for RELEASE or DEBUG builds
+#
+macro(_Boost_FIND_LIBRARY var build_type)
+
+  find_library(${var} ${ARGN})
+
+  if(${var})
+    # If this is the first library found then save Boost_LIBRARY_DIR_[RELEASE,DEBUG].
+    if(NOT Boost_LIBRARY_DIR_${build_type})
+      get_filename_component(_dir "${${var}}" PATH)
+      set(Boost_LIBRARY_DIR_${build_type} "${_dir}" CACHE PATH "Boost library directory ${build_type}" FORCE)
+    endif()
+  elseif(_Boost_FIND_LIBRARY_HINTS_FOR_COMPONENT)
+    # Try component-specific hints but do not save Boost_LIBRARY_DIR_[RELEASE,DEBUG].
+    find_library(${var} HINTS ${_Boost_FIND_LIBRARY_HINTS_FOR_COMPONENT} ${ARGN})
+  endif()
+
+  # If Boost_LIBRARY_DIR_[RELEASE,DEBUG] is known then search only there.
+  if(Boost_LIBRARY_DIR_${build_type})
+    set(_boost_LIBRARY_SEARCH_DIRS_${build_type} ${Boost_LIBRARY_DIR_${build_type}} NO_DEFAULT_PATH NO_CMAKE_FIND_ROOT_PATH)
+    if(Boost_DEBUG)
+      message(STATUS "[ ${CMAKE_CURRENT_LIST_FILE}:${CMAKE_CURRENT_LIST_LINE} ] "
+        " Boost_LIBRARY_DIR_${build_type} = ${Boost_LIBRARY_DIR_${build_type}}"
+        " _boost_LIBRARY_SEARCH_DIRS_${build_type} = ${_boost_LIBRARY_SEARCH_DIRS_${build_type}}")
+    endif()
+  endif()
+endmacro()
+
+#-------------------------------------------------------------------------------
+
+#
+# Runs compiler with "-dumpversion" and parses major/minor
+# version with a regex.
+#
+function(_Boost_COMPILER_DUMPVERSION _OUTPUT_VERSION)
+
+  exec_program(${CMAKE_CXX_COMPILER}
+    ARGS ${CMAKE_CXX_COMPILER_ARG1} -dumpversion
+    OUTPUT_VARIABLE _boost_COMPILER_VERSION
+  )
+  string(REGEX REPLACE "([0-9])\\.([0-9])(\\.[0-9])?" "\\1\\2"
+    _boost_COMPILER_VERSION ${_boost_COMPILER_VERSION})
+
+  set(${_OUTPUT_VERSION} ${_boost_COMPILER_VERSION} PARENT_SCOPE)
+endfunction()
+
+#
+# Take a list of libraries with "thread" in it
+# and prepend duplicates with "thread_${Boost_THREADAPI}"
+# at the front of the list
+#
+function(_Boost_PREPEND_LIST_WITH_THREADAPI _output)
+  set(_orig_libnames ${ARGN})
+  string(REPLACE "thread" "thread_${Boost_THREADAPI}" _threadapi_libnames "${_orig_libnames}")
+  set(${_output} ${_threadapi_libnames} ${_orig_libnames} PARENT_SCOPE)
+endfunction()
+
+#
+# If a library is found, replace its cache entry with its REALPATH
+#
+function(_Boost_SWAP_WITH_REALPATH _library _docstring)
+  if(${_library})
+    get_filename_component(_boost_filepathreal ${${_library}} REALPATH)
+    unset(${_library} CACHE)
+    set(${_library} ${_boost_filepathreal} CACHE FILEPATH "${_docstring}")
+  endif()
+endfunction()
+
+function(_Boost_CHECK_SPELLING _var)
+  if(${_var})
+    string(TOUPPER ${_var} _var_UC)
+    message(FATAL_ERROR "ERROR: ${_var} is not the correct spelling.  The proper spelling is ${_var_UC}.")
+  endif()
+endfunction()
+
+# Guesses Boost's compiler prefix used in built library names
+# Returns the guess by setting the variable pointed to by _ret
+function(_Boost_GUESS_COMPILER_PREFIX _ret)
+  if(CMAKE_CXX_COMPILER_ID STREQUAL "Intel"
+      OR CMAKE_CXX_COMPILER MATCHES "icl"
+      OR CMAKE_CXX_COMPILER MATCHES "icpc")
+    if(WIN32)
+      set (_boost_COMPILER "-iw")
+    else()
+      set (_boost_COMPILER "-il")
+    endif()
+  elseif (GHSMULTI)
+    set(_boost_COMPILER "-ghs")
+  elseif (MSVC14)
+    set(_boost_COMPILER "-vc140")
+  elseif (MSVC12)
+    set(_boost_COMPILER "-vc120")
+  elseif (MSVC11)
+    set(_boost_COMPILER "-vc110")
+  elseif (MSVC10)
+    set(_boost_COMPILER "-vc100")
+  elseif (MSVC90)
+    set(_boost_COMPILER "-vc90")
+  elseif (MSVC80)
+    set(_boost_COMPILER "-vc80")
+  elseif (MSVC71)
+    set(_boost_COMPILER "-vc71")
+  elseif (MSVC70) # Good luck!
+    set(_boost_COMPILER "-vc7") # yes, this is correct
+  elseif (MSVC60) # Good luck!
+    set(_boost_COMPILER "-vc6") # yes, this is correct
+  elseif (BORLAND)
+    set(_boost_COMPILER "-bcb")
+  elseif(CMAKE_CXX_COMPILER_ID STREQUAL "SunPro")
+    set(_boost_COMPILER "-sw")
+  elseif (MINGW)
+    if(${Boost_MAJOR_VERSION}.${Boost_MINOR_VERSION} VERSION_LESS 1.34)
+        set(_boost_COMPILER "-mgw") # no GCC version encoding prior to 1.34
+    else()
+      _Boost_COMPILER_DUMPVERSION(_boost_COMPILER_VERSION)
+      set(_boost_COMPILER "-mgw${_boost_COMPILER_VERSION}")
+    endif()
+  elseif (UNIX)
+    if (CMAKE_COMPILER_IS_GNUCXX)
+      if(${Boost_MAJOR_VERSION}.${Boost_MINOR_VERSION} VERSION_LESS 1.34)
+        set(_boost_COMPILER "-gcc") # no GCC version encoding prior to 1.34
+      else()
+        _Boost_COMPILER_DUMPVERSION(_boost_COMPILER_VERSION)
+        # Determine which version of GCC we have.
+        if(APPLE)
+          if(Boost_MINOR_VERSION)
+            if(${Boost_MINOR_VERSION} GREATER 35)
+              # In Boost 1.36.0 and newer, the mangled compiler name used
+              # on Mac OS X/Darwin is "xgcc".
+              set(_boost_COMPILER "-xgcc${_boost_COMPILER_VERSION}")
+            else()
+              # In Boost <= 1.35.0, there is no mangled compiler name for
+              # the Mac OS X/Darwin version of GCC.
+              set(_boost_COMPILER "")
+            endif()
+          else()
+            # We don't know the Boost version, so assume it's
+            # pre-1.36.0.
+            set(_boost_COMPILER "")
+          endif()
+        else()
+          set(_boost_COMPILER "-gcc${_boost_COMPILER_VERSION}")
+        endif()
+      endif()
+    endif ()
+  else()
+    # TODO at least Boost_DEBUG here?
+    set(_boost_COMPILER "")
+  endif()
+  set(${_ret} ${_boost_COMPILER} PARENT_SCOPE)
+endfunction()
+
+#
+# End functions/macros
+#
+#-------------------------------------------------------------------------------
+
+#-------------------------------------------------------------------------------
+# main.
+#-------------------------------------------------------------------------------
+
+
+# If the user sets Boost_LIBRARY_DIR, use it as the default for both
+# configurations.
+if(NOT Boost_LIBRARY_DIR_RELEASE AND Boost_LIBRARY_DIR)
+  set(Boost_LIBRARY_DIR_RELEASE "${Boost_LIBRARY_DIR}")
+endif()
+if(NOT Boost_LIBRARY_DIR_DEBUG AND Boost_LIBRARY_DIR)
+  set(Boost_LIBRARY_DIR_DEBUG   "${Boost_LIBRARY_DIR}")
+endif()
+
+if(NOT DEFINED Boost_USE_MULTITHREADED)
+    set(Boost_USE_MULTITHREADED TRUE)
+endif()
+if(NOT DEFINED Boost_USE_DEBUG_RUNTIME)
+  set(Boost_USE_DEBUG_RUNTIME TRUE)
+endif()
+
+# Check the version of Boost against the requested version.
+if(Boost_FIND_VERSION AND NOT Boost_FIND_VERSION_MINOR)
+  message(SEND_ERROR "When requesting a specific version of Boost, you must provide at least the major and minor version numbers, e.g., 1.34")
+endif()
+
+if(Boost_FIND_VERSION_EXACT)
+  # The version may appear in a directory with or without the patch
+  # level, even when the patch level is non-zero.
+  set(_boost_TEST_VERSIONS
+    "${Boost_FIND_VERSION_MAJOR}.${Boost_FIND_VERSION_MINOR}.${Boost_FIND_VERSION_PATCH}"
+    "${Boost_FIND_VERSION_MAJOR}.${Boost_FIND_VERSION_MINOR}")
+else()
+  # The user has not requested an exact version.  Among known
+  # versions, find those that are acceptable to the user request.
+  set(_Boost_KNOWN_VERSIONS ${Boost_ADDITIONAL_VERSIONS}
+    "1.58.0" "1.58" "1.57.0" "1.57" "1.56.0" "1.56" "1.55.0" "1.55" "1.54.0" "1.54"
+    "1.53.0" "1.53" "1.52.0" "1.52" "1.51.0" "1.51"
+    "1.50.0" "1.50" "1.49.0" "1.49" "1.48.0" "1.48" "1.47.0" "1.47" "1.46.1"
+    "1.46.0" "1.46" "1.45.0" "1.45" "1.44.0" "1.44" "1.43.0" "1.43" "1.42.0" "1.42"
+    "1.41.0" "1.41" "1.40.0" "1.40" "1.39.0" "1.39" "1.38.0" "1.38" "1.37.0" "1.37"
+    "1.36.1" "1.36.0" "1.36" "1.35.1" "1.35.0" "1.35" "1.34.1" "1.34.0"
+    "1.34" "1.33.1" "1.33.0" "1.33")
+  set(_boost_TEST_VERSIONS)
+  if(Boost_FIND_VERSION)
+    set(_Boost_FIND_VERSION_SHORT "${Boost_FIND_VERSION_MAJOR}.${Boost_FIND_VERSION_MINOR}")
+    # Select acceptable versions.
+    foreach(version ${_Boost_KNOWN_VERSIONS})
+      if(NOT "${version}" VERSION_LESS "${Boost_FIND_VERSION}")
+        # This version is high enough.
+        list(APPEND _boost_TEST_VERSIONS "${version}")
+      elseif("${version}.99" VERSION_EQUAL "${_Boost_FIND_VERSION_SHORT}.99")
+        # This version is a short-form for the requested version with
+        # the patch level dropped.
+        list(APPEND _boost_TEST_VERSIONS "${version}")
+      endif()
+    endforeach()
+  else()
+    # Any version is acceptable.
+    set(_boost_TEST_VERSIONS "${_Boost_KNOWN_VERSIONS}")
+  endif()
+endif()
+
+# The reason that we failed to find Boost. This will be set to a
+# user-friendly message when we fail to find some necessary piece of
+# Boost.
+set(Boost_ERROR_REASON)
+
+if(Boost_DEBUG)
+  # Output some of their choices
+  message(STATUS "[ ${CMAKE_CURRENT_LIST_FILE}:${CMAKE_CURRENT_LIST_LINE} ] "
+                 "_boost_TEST_VERSIONS = ${_boost_TEST_VERSIONS}")
+  message(STATUS "[ ${CMAKE_CURRENT_LIST_FILE}:${CMAKE_CURRENT_LIST_LINE} ] "
+                 "Boost_USE_MULTITHREADED = ${Boost_USE_MULTITHREADED}")
+  message(STATUS "[ ${CMAKE_CURRENT_LIST_FILE}:${CMAKE_CURRENT_LIST_LINE} ] "
+                 "Boost_USE_STATIC_LIBS = ${Boost_USE_STATIC_LIBS}")
+  message(STATUS "[ ${CMAKE_CURRENT_LIST_FILE}:${CMAKE_CURRENT_LIST_LINE} ] "
+                 "Boost_USE_STATIC_RUNTIME = ${Boost_USE_STATIC_RUNTIME}")
+  message(STATUS "[ ${CMAKE_CURRENT_LIST_FILE}:${CMAKE_CURRENT_LIST_LINE} ] "
+                 "Boost_ADDITIONAL_VERSIONS = ${Boost_ADDITIONAL_VERSIONS}")
+  message(STATUS "[ ${CMAKE_CURRENT_LIST_FILE}:${CMAKE_CURRENT_LIST_LINE} ] "
+                 "Boost_NO_SYSTEM_PATHS = ${Boost_NO_SYSTEM_PATHS}")
+endif()
+
+if(WIN32)
+  # In windows, automatic linking is performed, so you do not have
+  # to specify the libraries.  If you are linking to a dynamic
+  # runtime, then you can choose to link to either a static or a
+  # dynamic Boost library, the default is to do a static link.  You
+  # can alter this for a specific library "whatever" by defining
+  # BOOST_WHATEVER_DYN_LINK to force Boost library "whatever" to be
+  # linked dynamically.  Alternatively you can force all Boost
+  # libraries to dynamic link by defining BOOST_ALL_DYN_LINK.
+
+  # This feature can be disabled for Boost library "whatever" by
+  # defining BOOST_WHATEVER_NO_LIB, or for all of Boost by defining
+  # BOOST_ALL_NO_LIB.
+
+  # If you want to observe which libraries are being linked against
+  # then defining BOOST_LIB_DIAGNOSTIC will cause the auto-linking
+  # code to emit a #pragma message each time a library is selected
+  # for linking.
+  set(Boost_LIB_DIAGNOSTIC_DEFINITIONS "-DBOOST_LIB_DIAGNOSTIC")
+endif()
+
+_Boost_CHECK_SPELLING(Boost_ROOT)
+_Boost_CHECK_SPELLING(Boost_LIBRARYDIR)
+_Boost_CHECK_SPELLING(Boost_INCLUDEDIR)
+
+# Collect environment variable inputs as hints.  Do not consider changes.
+foreach(v BOOSTROOT BOOST_ROOT BOOST_INCLUDEDIR BOOST_LIBRARYDIR)
+  set(_env $ENV{${v}})
+  if(_env)
+    file(TO_CMAKE_PATH "${_env}" _ENV_${v})
+  else()
+    set(_ENV_${v} "")
+  endif()
+endforeach()
+if(NOT _ENV_BOOST_ROOT AND _ENV_BOOSTROOT)
+  set(_ENV_BOOST_ROOT "${_ENV_BOOSTROOT}")
+endif()
+
+# Collect inputs and cached results.  Detect changes since the last run.
+if(NOT BOOST_ROOT AND BOOSTROOT)
+  set(BOOST_ROOT "${BOOSTROOT}")
+endif()
+set(_Boost_VARS_DIR
+  BOOST_ROOT
+  Boost_NO_SYSTEM_PATHS
+  )
+
+if(Boost_DEBUG)
+  message(STATUS "[ ${CMAKE_CURRENT_LIST_FILE}:${CMAKE_CURRENT_LIST_LINE} ] "
+                 "Declared as CMake or Environmental Variables:")
+  message(STATUS "[ ${CMAKE_CURRENT_LIST_FILE}:${CMAKE_CURRENT_LIST_LINE} ] "
+                 "  BOOST_ROOT = ${BOOST_ROOT}")
+  message(STATUS "[ ${CMAKE_CURRENT_LIST_FILE}:${CMAKE_CURRENT_LIST_LINE} ] "
+                 "  BOOST_INCLUDEDIR = ${BOOST_INCLUDEDIR}")
+  message(STATUS "[ ${CMAKE_CURRENT_LIST_FILE}:${CMAKE_CURRENT_LIST_LINE} ] "
+                 "  BOOST_LIBRARYDIR = ${BOOST_LIBRARYDIR}")
+  message(STATUS "[ ${CMAKE_CURRENT_LIST_FILE}:${CMAKE_CURRENT_LIST_LINE} ] "
+                 "_boost_TEST_VERSIONS = ${_boost_TEST_VERSIONS}")
+endif()
+
+# ------------------------------------------------------------------------
+#  Search for Boost include DIR
+# ------------------------------------------------------------------------
+
+set(_Boost_VARS_INC BOOST_INCLUDEDIR Boost_INCLUDE_DIR Boost_ADDITIONAL_VERSIONS)
+_Boost_CHANGE_DETECT(_Boost_CHANGE_INCDIR ${_Boost_VARS_DIR} ${_Boost_VARS_INC})
+# Clear Boost_INCLUDE_DIR if it did not change but other input affecting the
+# location did.  We will find a new one based on the new inputs.
+if(_Boost_CHANGE_INCDIR AND NOT _Boost_INCLUDE_DIR_CHANGED)
+  unset(Boost_INCLUDE_DIR CACHE)
+endif()
+
+if(NOT Boost_INCLUDE_DIR)
+  set(_boost_INCLUDE_SEARCH_DIRS "")
+  if(BOOST_INCLUDEDIR)
+    list(APPEND _boost_INCLUDE_SEARCH_DIRS ${BOOST_INCLUDEDIR})
+  elseif(_ENV_BOOST_INCLUDEDIR)
+    list(APPEND _boost_INCLUDE_SEARCH_DIRS ${_ENV_BOOST_INCLUDEDIR})
+  endif()
+
+  if( BOOST_ROOT )
+    list(APPEND _boost_INCLUDE_SEARCH_DIRS ${BOOST_ROOT}/include ${BOOST_ROOT})
+  elseif( _ENV_BOOST_ROOT )
+    list(APPEND _boost_INCLUDE_SEARCH_DIRS ${_ENV_BOOST_ROOT}/include ${_ENV_BOOST_ROOT})
+  endif()
+
+  if( Boost_NO_SYSTEM_PATHS)
+    list(APPEND _boost_INCLUDE_SEARCH_DIRS NO_CMAKE_SYSTEM_PATH)
+  else()
+    list(APPEND _boost_INCLUDE_SEARCH_DIRS PATHS
+      C:/boost/include
+      C:/boost
+      /sw/local/include
+      )
+  endif()
+
+  # Try to find Boost by stepping backwards through the Boost versions
+  # we know about.
+  # Build a list of path suffixes for each version.
+  set(_boost_PATH_SUFFIXES)
+  foreach(_boost_VER ${_boost_TEST_VERSIONS})
+    # Add in a path suffix, based on the required version, ideally
+    # we could read this from version.hpp, but for that to work we'd
+    # need to know the include dir already
+    set(_boost_BOOSTIFIED_VERSION)
+
+    # Transform 1.35 => 1_35 and 1.36.0 => 1_36_0
+    if(_boost_VER MATCHES "([0-9]+)\\.([0-9]+)\\.([0-9]+)")
+        set(_boost_BOOSTIFIED_VERSION
+          "${CMAKE_MATCH_1}_${CMAKE_MATCH_2}_${CMAKE_MATCH_3}")
+    elseif(_boost_VER MATCHES "([0-9]+)\\.([0-9]+)")
+        set(_boost_BOOSTIFIED_VERSION
+          "${CMAKE_MATCH_1}_${CMAKE_MATCH_2}")
+    endif()
+
+    list(APPEND _boost_PATH_SUFFIXES
+      "boost-${_boost_BOOSTIFIED_VERSION}"
+      "boost_${_boost_BOOSTIFIED_VERSION}"
+      "boost/boost-${_boost_BOOSTIFIED_VERSION}"
+      "boost/boost_${_boost_BOOSTIFIED_VERSION}"
+      )
+
+  endforeach()
+
+  if(Boost_DEBUG)
+    message(STATUS "[ ${CMAKE_CURRENT_LIST_FILE}:${CMAKE_CURRENT_LIST_LINE} ] "
+                   "Include debugging info:")
+    message(STATUS "[ ${CMAKE_CURRENT_LIST_FILE}:${CMAKE_CURRENT_LIST_LINE} ] "
+                   "  _boost_INCLUDE_SEARCH_DIRS = ${_boost_INCLUDE_SEARCH_DIRS}")
+    message(STATUS "[ ${CMAKE_CURRENT_LIST_FILE}:${CMAKE_CURRENT_LIST_LINE} ] "
+                   "  _boost_PATH_SUFFIXES = ${_boost_PATH_SUFFIXES}")
+  endif()
+
+  # Look for a standard boost header file.
+  find_path(Boost_INCLUDE_DIR
+    NAMES         boost/config.hpp
+    HINTS         ${_boost_INCLUDE_SEARCH_DIRS}
+    PATH_SUFFIXES ${_boost_PATH_SUFFIXES}
+    )
+endif()
+
+# ------------------------------------------------------------------------
+#  Extract version information from version.hpp
+# ------------------------------------------------------------------------
+
+# Set Boost_FOUND based only on header location and version.
+# It will be updated below for component libraries.
+if(Boost_INCLUDE_DIR)
+  if(Boost_DEBUG)
+    message(STATUS "[ ${CMAKE_CURRENT_LIST_FILE}:${CMAKE_CURRENT_LIST_LINE} ] "
+                   "location of version.hpp: ${Boost_INCLUDE_DIR}/boost/version.hpp")
+  endif()
+
+  # Extract Boost_VERSION and Boost_LIB_VERSION from version.hpp
+  set(Boost_VERSION 0)
+  set(Boost_LIB_VERSION "")
+  file(STRINGS "${Boost_INCLUDE_DIR}/boost/version.hpp" _boost_VERSION_HPP_CONTENTS REGEX "#define BOOST_(LIB_)?VERSION ")
+  set(_Boost_VERSION_REGEX "([0-9]+)")
+  set(_Boost_LIB_VERSION_REGEX "\"([0-9_]+)\"")
+  foreach(v VERSION LIB_VERSION)
+    if("${_boost_VERSION_HPP_CONTENTS}" MATCHES "#define BOOST_${v} ${_Boost_${v}_REGEX}")
+      set(Boost_${v} "${CMAKE_MATCH_1}")
+    endif()
+  endforeach()
+  unset(_boost_VERSION_HPP_CONTENTS)
+
+  math(EXPR Boost_MAJOR_VERSION "${Boost_VERSION} / 100000")
+  math(EXPR Boost_MINOR_VERSION "${Boost_VERSION} / 100 % 1000")
+  math(EXPR Boost_SUBMINOR_VERSION "${Boost_VERSION} % 100")
+
+  set(Boost_ERROR_REASON
+    "${Boost_ERROR_REASON}Boost version: ${Boost_MAJOR_VERSION}.${Boost_MINOR_VERSION}.${Boost_SUBMINOR_VERSION}\nBoost include path: ${Boost_INCLUDE_DIR}")
+  if(Boost_DEBUG)
+    message(STATUS "[ ${CMAKE_CURRENT_LIST_FILE}:${CMAKE_CURRENT_LIST_LINE} ] "
+                   "version.hpp reveals boost "
+                   "${Boost_MAJOR_VERSION}.${Boost_MINOR_VERSION}.${Boost_SUBMINOR_VERSION}")
+  endif()
+
+  if(Boost_FIND_VERSION)
+    # Set Boost_FOUND based on requested version.
+    set(_Boost_VERSION "${Boost_MAJOR_VERSION}.${Boost_MINOR_VERSION}.${Boost_SUBMINOR_VERSION}")
+    if("${_Boost_VERSION}" VERSION_LESS "${Boost_FIND_VERSION}")
+      set(Boost_FOUND 0)
+      set(_Boost_VERSION_AGE "old")
+    elseif(Boost_FIND_VERSION_EXACT AND
+        NOT "${_Boost_VERSION}" VERSION_EQUAL "${Boost_FIND_VERSION}")
+      set(Boost_FOUND 0)
+      set(_Boost_VERSION_AGE "new")
+    else()
+      set(Boost_FOUND 1)
+    endif()
+    if(NOT Boost_FOUND)
+      # State that we found a version of Boost that is too new or too old.
+      set(Boost_ERROR_REASON
+        "${Boost_ERROR_REASON}\nDetected version of Boost is too ${_Boost_VERSION_AGE}. Requested version was ${Boost_FIND_VERSION_MAJOR}.${Boost_FIND_VERSION_MINOR}")
+      if (Boost_FIND_VERSION_PATCH)
+        set(Boost_ERROR_REASON
+          "${Boost_ERROR_REASON}.${Boost_FIND_VERSION_PATCH}")
+      endif ()
+      if (NOT Boost_FIND_VERSION_EXACT)
+        set(Boost_ERROR_REASON "${Boost_ERROR_REASON} (or newer)")
+      endif ()
+      set(Boost_ERROR_REASON "${Boost_ERROR_REASON}.")
+    endif ()
+  else()
+    # Caller will accept any Boost version.
+    set(Boost_FOUND 1)
+  endif()
+else()
+  set(Boost_FOUND 0)
+  set(Boost_ERROR_REASON
+    "${Boost_ERROR_REASON}Unable to find the Boost header files. Please set BOOST_ROOT to the root directory containing Boost or BOOST_INCLUDEDIR to the directory containing Boost's headers.")
+endif()
+
+# ------------------------------------------------------------------------
+#  Prefix initialization
+# ------------------------------------------------------------------------
+
+set(Boost_LIB_PREFIX "")
+if ( (GHSMULTI AND Boost_USE_STATIC_LIBS) OR
+    (WIN32 AND Boost_USE_STATIC_LIBS AND NOT CYGWIN) )
+  set(Boost_LIB_PREFIX "lib")
+endif()
+
+if ( NOT Boost_NAMESPACE )
+  set(Boost_NAMESPACE "boost")
+endif()
+
+# ------------------------------------------------------------------------
+#  Suffix initialization and compiler suffix detection.
+# ------------------------------------------------------------------------
+
+set(_Boost_VARS_NAME
+  Boost_NAMESPACE
+  Boost_COMPILER
+  Boost_THREADAPI
+  Boost_USE_DEBUG_PYTHON
+  Boost_USE_MULTITHREADED
+  Boost_USE_STATIC_LIBS
+  Boost_USE_STATIC_RUNTIME
+  Boost_USE_STLPORT
+  Boost_USE_STLPORT_DEPRECATED_NATIVE_IOSTREAMS
+  )
+_Boost_CHANGE_DETECT(_Boost_CHANGE_LIBNAME ${_Boost_VARS_NAME})
+
+# Setting some more suffixes for the library
+if (Boost_COMPILER)
+  set(_boost_COMPILER ${Boost_COMPILER})
+  if(Boost_DEBUG)
+    message(STATUS "[ ${CMAKE_CURRENT_LIST_FILE}:${CMAKE_CURRENT_LIST_LINE} ] "
+                   "using user-specified Boost_COMPILER = ${_boost_COMPILER}")
+  endif()
+else()
+  # Attempt to guess the compiler suffix
+  # NOTE: this is not perfect yet, if you experience any issues
+  # please report them and use the Boost_COMPILER variable
+  # to work around the problems.
+  _Boost_GUESS_COMPILER_PREFIX(_boost_COMPILER)
+  if(Boost_DEBUG)
+    message(STATUS "[ ${CMAKE_CURRENT_LIST_FILE}:${CMAKE_CURRENT_LIST_LINE} ] "
+      "guessed _boost_COMPILER = ${_boost_COMPILER}")
+  endif()
+endif()
+
+set (_boost_MULTITHREADED "-mt")
+if( NOT Boost_USE_MULTITHREADED )
+  set (_boost_MULTITHREADED "")
+endif()
+if(Boost_DEBUG)
+  message(STATUS "[ ${CMAKE_CURRENT_LIST_FILE}:${CMAKE_CURRENT_LIST_LINE} ] "
+    "_boost_MULTITHREADED = ${_boost_MULTITHREADED}")
+endif()
+
+#======================
+# Systematically build up the Boost ABI tag
+# http://boost.org/doc/libs/1_41_0/more/getting_started/windows.html#library-naming
+set( _boost_RELEASE_ABI_TAG "-")
+set( _boost_DEBUG_ABI_TAG   "-")
+# Key       Use this library when:
+#  s        linking statically to the C++ standard library and
+#           compiler runtime support libraries.
+if(Boost_USE_STATIC_RUNTIME)
+  set( _boost_RELEASE_ABI_TAG "${_boost_RELEASE_ABI_TAG}s")
+  set( _boost_DEBUG_ABI_TAG   "${_boost_DEBUG_ABI_TAG}s")
+endif()
+#  g        using debug versions of the standard and runtime
+#           support libraries
+if(WIN32 AND Boost_USE_DEBUG_RUNTIME)
+  if(MSVC OR "${CMAKE_CXX_COMPILER}" MATCHES "icl"
+          OR "${CMAKE_CXX_COMPILER}" MATCHES "icpc")
+    set(_boost_DEBUG_ABI_TAG "${_boost_DEBUG_ABI_TAG}g")
+  endif()
+endif()
+#  y        using special debug build of python
+if(Boost_USE_DEBUG_PYTHON)
+  set(_boost_DEBUG_ABI_TAG "${_boost_DEBUG_ABI_TAG}y")
+endif()
+#  d        using a debug version of your code
+set(_boost_DEBUG_ABI_TAG "${_boost_DEBUG_ABI_TAG}d")
+#  p        using the STLport standard library rather than the
+#           default one supplied with your compiler
+if(Boost_USE_STLPORT)
+  set( _boost_RELEASE_ABI_TAG "${_boost_RELEASE_ABI_TAG}p")
+  set( _boost_DEBUG_ABI_TAG   "${_boost_DEBUG_ABI_TAG}p")
+endif()
+#  n        using the STLport deprecated "native iostreams" feature
+if(Boost_USE_STLPORT_DEPRECATED_NATIVE_IOSTREAMS)
+  set( _boost_RELEASE_ABI_TAG "${_boost_RELEASE_ABI_TAG}n")
+  set( _boost_DEBUG_ABI_TAG   "${_boost_DEBUG_ABI_TAG}n")
+endif()
+
+if(Boost_DEBUG)
+  message(STATUS "[ ${CMAKE_CURRENT_LIST_FILE}:${CMAKE_CURRENT_LIST_LINE} ] "
+    "_boost_RELEASE_ABI_TAG = ${_boost_RELEASE_ABI_TAG}")
+  message(STATUS "[ ${CMAKE_CURRENT_LIST_FILE}:${CMAKE_CURRENT_LIST_LINE} ] "
+    "_boost_DEBUG_ABI_TAG = ${_boost_DEBUG_ABI_TAG}")
+endif()
+
+# ------------------------------------------------------------------------
+#  Begin finding boost libraries
+# ------------------------------------------------------------------------
+
+set(_Boost_VARS_LIB "")
+foreach(c DEBUG RELEASE)
+  set(_Boost_VARS_LIB_${c} BOOST_LIBRARYDIR Boost_LIBRARY_DIR_${c})
+  list(APPEND _Boost_VARS_LIB ${_Boost_VARS_LIB_${c}})
+  _Boost_CHANGE_DETECT(_Boost_CHANGE_LIBDIR_${c} ${_Boost_VARS_DIR} ${_Boost_VARS_LIB_${c}} Boost_INCLUDE_DIR)
+  # Clear Boost_LIBRARY_DIR_${c} if it did not change but other input affecting the
+  # location did.  We will find a new one based on the new inputs.
+  if(_Boost_CHANGE_LIBDIR_${c} AND NOT _Boost_LIBRARY_DIR_${c}_CHANGED)
+    unset(Boost_LIBRARY_DIR_${c} CACHE)
+  endif()
+
+  # If Boost_LIBRARY_DIR_[RELEASE,DEBUG] is set, prefer its value.
+  if(Boost_LIBRARY_DIR_${c})
+    set(_boost_LIBRARY_SEARCH_DIRS_${c} ${Boost_LIBRARY_DIR_${c}} NO_DEFAULT_PATH NO_CMAKE_FIND_ROOT_PATH)
+  else()
+    set(_boost_LIBRARY_SEARCH_DIRS_${c} "")
+    if(BOOST_LIBRARYDIR)
+      list(APPEND _boost_LIBRARY_SEARCH_DIRS_${c} ${BOOST_LIBRARYDIR})
+    elseif(_ENV_BOOST_LIBRARYDIR)
+      list(APPEND _boost_LIBRARY_SEARCH_DIRS_${c} ${_ENV_BOOST_LIBRARYDIR})
+    endif()
+
+    if(BOOST_ROOT)
+      list(APPEND _boost_LIBRARY_SEARCH_DIRS_${c} ${BOOST_ROOT}/lib ${BOOST_ROOT}/stage/lib)
+    elseif(_ENV_BOOST_ROOT)
+      list(APPEND _boost_LIBRARY_SEARCH_DIRS_${c} ${_ENV_BOOST_ROOT}/lib ${_ENV_BOOST_ROOT}/stage/lib)
+    endif()
+
+    list(APPEND _boost_LIBRARY_SEARCH_DIRS_${c}
+      ${Boost_INCLUDE_DIR}/lib
+      ${Boost_INCLUDE_DIR}/../lib
+      ${Boost_INCLUDE_DIR}/stage/lib
+      )
+    if( Boost_NO_SYSTEM_PATHS )
+      list(APPEND _boost_LIBRARY_SEARCH_DIRS_${c} NO_CMAKE_SYSTEM_PATH)
+    else()
+      list(APPEND _boost_LIBRARY_SEARCH_DIRS_${c} PATHS
+        C:/boost/lib
+        C:/boost
+        /sw/local/lib
+        )
+    endif()
+  endif()
+endforeach()
+
+if(Boost_DEBUG)
+  message(STATUS "[ ${CMAKE_CURRENT_LIST_FILE}:${CMAKE_CURRENT_LIST_LINE} ] "
+    "_boost_LIBRARY_SEARCH_DIRS_RELEASE = ${_boost_LIBRARY_SEARCH_DIRS_RELEASE}"
+    "_boost_LIBRARY_SEARCH_DIRS_DEBUG   = ${_boost_LIBRARY_SEARCH_DIRS_DEBUG}")
+endif()
+
+# Support preference of static libs by adjusting CMAKE_FIND_LIBRARY_SUFFIXES
+if( Boost_USE_STATIC_LIBS )
+  set( _boost_ORIG_CMAKE_FIND_LIBRARY_SUFFIXES ${CMAKE_FIND_LIBRARY_SUFFIXES})
+  if(WIN32)
+    set(CMAKE_FIND_LIBRARY_SUFFIXES .lib .a ${CMAKE_FIND_LIBRARY_SUFFIXES})
+  else()
+    set(CMAKE_FIND_LIBRARY_SUFFIXES .a )
+  endif()
+endif()
+
+# We want to use the tag inline below without risking double dashes
+if(_boost_RELEASE_ABI_TAG)
+  if(${_boost_RELEASE_ABI_TAG} STREQUAL "-")
+    set(_boost_RELEASE_ABI_TAG "")
+  endif()
+endif()
+if(_boost_DEBUG_ABI_TAG)
+  if(${_boost_DEBUG_ABI_TAG} STREQUAL "-")
+    set(_boost_DEBUG_ABI_TAG "")
+  endif()
+endif()
+
+# The previous behavior of FindBoost when Boost_USE_STATIC_LIBS was enabled
+# on WIN32 was to:
+#  1. Search for static libs compiled against a SHARED C++ standard runtime library (use if found)
+#  2. Search for static libs compiled against a STATIC C++ standard runtime library (use if found)
+# We maintain this behavior since changing it could break people's builds.
+# To disable the ambiguous behavior, the user need only
+# set Boost_USE_STATIC_RUNTIME either ON or OFF.
+set(_boost_STATIC_RUNTIME_WORKAROUND false)
+if(WIN32 AND Boost_USE_STATIC_LIBS)
+  if(NOT DEFINED Boost_USE_STATIC_RUNTIME)
+    set(_boost_STATIC_RUNTIME_WORKAROUND true)
+  endif()
+endif()
+
+# On versions < 1.35, remove the System library from the considered list
+# since it wasn't added until 1.35.
+if(Boost_VERSION AND Boost_FIND_COMPONENTS)
+   if(Boost_VERSION LESS 103500)
+     list(REMOVE_ITEM Boost_FIND_COMPONENTS system)
+   endif()
+endif()
+
+# If the user changed any of our control inputs flush previous results.
+if(_Boost_CHANGE_LIBDIR OR _Boost_CHANGE_LIBNAME)
+  foreach(COMPONENT ${_Boost_COMPONENTS_SEARCHED})
+    string(TOUPPER ${COMPONENT} UPPERCOMPONENT)
+    foreach(c DEBUG RELEASE)
+      set(_var Boost_${UPPERCOMPONENT}_LIBRARY_${c})
+      unset(${_var} CACHE)
+      set(${_var} "${_var}-NOTFOUND")
+    endforeach()
+  endforeach()
+  set(_Boost_COMPONENTS_SEARCHED "")
+endif()
+
+foreach(COMPONENT ${Boost_FIND_COMPONENTS})
+  string(TOUPPER ${COMPONENT} UPPERCOMPONENT)
+
+  set( _boost_docstring_release "Boost ${COMPONENT} library (release)")
+  set( _boost_docstring_debug   "Boost ${COMPONENT} library (debug)")
+
+  # Compute component-specific hints.
+  set(_Boost_FIND_LIBRARY_HINTS_FOR_COMPONENT "")
+  if(${COMPONENT} STREQUAL "mpi" OR ${COMPONENT} STREQUAL "mpi_python" OR
+     ${COMPONENT} STREQUAL "graph_parallel")
+    foreach(lib ${MPI_CXX_LIBRARIES} ${MPI_C_LIBRARIES})
+      if(IS_ABSOLUTE "${lib}")
+        get_filename_component(libdir "${lib}" PATH)
+        string(REPLACE "\\" "/" libdir "${libdir}")
+        list(APPEND _Boost_FIND_LIBRARY_HINTS_FOR_COMPONENT ${libdir})
+      endif()
+    endforeach()
+  endif()
+
+  # Consolidate and report component-specific hints.
+  if(_Boost_FIND_LIBRARY_HINTS_FOR_COMPONENT)
+    list(REMOVE_DUPLICATES _Boost_FIND_LIBRARY_HINTS_FOR_COMPONENT)
+    if(Boost_DEBUG)
+      message(STATUS "[ ${CMAKE_CURRENT_LIST_FILE}:${CMAKE_CURRENT_LIST_LINE} ] "
+        "Component-specific library search paths for ${COMPONENT}: "
+        "${_Boost_FIND_LIBRARY_HINTS_FOR_COMPONENT}")
+    endif()
+  endif()
+
+  #
+  # Find RELEASE libraries
+  #
+  set(_boost_RELEASE_NAMES
+    ${Boost_LIB_PREFIX}${Boost_NAMESPACE}_${COMPONENT}${_boost_COMPILER}${_boost_MULTITHREADED}${_boost_RELEASE_ABI_TAG}-${Boost_LIB_VERSION}
+    ${Boost_LIB_PREFIX}${Boost_NAMESPACE}_${COMPONENT}${_boost_COMPILER}${_boost_MULTITHREADED}${_boost_RELEASE_ABI_TAG}
+    ${Boost_LIB_PREFIX}${Boost_NAMESPACE}_${COMPONENT}${_boost_MULTITHREADED}${_boost_RELEASE_ABI_TAG}-${Boost_LIB_VERSION}
+    ${Boost_LIB_PREFIX}${Boost_NAMESPACE}_${COMPONENT}${_boost_MULTITHREADED}${_boost_RELEASE_ABI_TAG}
+    ${Boost_LIB_PREFIX}${Boost_NAMESPACE}_${COMPONENT} )
+  if(_boost_STATIC_RUNTIME_WORKAROUND)
+    set(_boost_RELEASE_STATIC_ABI_TAG "-s${_boost_RELEASE_ABI_TAG}")
+    list(APPEND _boost_RELEASE_NAMES
+      ${Boost_LIB_PREFIX}${Boost_NAMESPACE}_${COMPONENT}${_boost_COMPILER}${_boost_MULTITHREADED}${_boost_RELEASE_STATIC_ABI_TAG}-${Boost_LIB_VERSION}
+      ${Boost_LIB_PREFIX}${Boost_NAMESPACE}_${COMPONENT}${_boost_COMPILER}${_boost_MULTITHREADED}${_boost_RELEASE_STATIC_ABI_TAG}
+      ${Boost_LIB_PREFIX}${Boost_NAMESPACE}_${COMPONENT}${_boost_MULTITHREADED}${_boost_RELEASE_STATIC_ABI_TAG}-${Boost_LIB_VERSION}
+      ${Boost_LIB_PREFIX}${Boost_NAMESPACE}_${COMPONENT}${_boost_MULTITHREADED}${_boost_RELEASE_STATIC_ABI_TAG} )
+  endif()
+  if(Boost_THREADAPI AND ${COMPONENT} STREQUAL "thread")
+     _Boost_PREPEND_LIST_WITH_THREADAPI(_boost_RELEASE_NAMES ${_boost_RELEASE_NAMES})
+  endif()
+  if(Boost_DEBUG)
+    message(STATUS "[ ${CMAKE_CURRENT_LIST_FILE}:${CMAKE_CURRENT_LIST_LINE} ] "
+                   "Searching for ${UPPERCOMPONENT}_LIBRARY_RELEASE: ${_boost_RELEASE_NAMES}")
+  endif()
+
+  # if Boost_LIBRARY_DIR_RELEASE is not defined,
+  # but Boost_LIBRARY_DIR_DEBUG is, look there first for RELEASE libs
+  if(NOT Boost_LIBRARY_DIR_RELEASE AND Boost_LIBRARY_DIR_DEBUG)
+    list(INSERT _boost_LIBRARY_SEARCH_DIRS_RELEASE 0 ${Boost_LIBRARY_DIR_DEBUG})
+  endif()
+
+  # Avoid passing backslashes to _Boost_FIND_LIBRARY due to macro re-parsing.
+  string(REPLACE "\\" "/" _boost_LIBRARY_SEARCH_DIRS_tmp "${_boost_LIBRARY_SEARCH_DIRS_RELEASE}")
+
+  _Boost_FIND_LIBRARY(Boost_${UPPERCOMPONENT}_LIBRARY_RELEASE RELEASE
+    NAMES ${_boost_RELEASE_NAMES}
+    HINTS ${_boost_LIBRARY_SEARCH_DIRS_tmp}
+    NAMES_PER_DIR
+    DOC "${_boost_docstring_release}"
+    )
+
+  #
+  # Find DEBUG libraries
+  #
+  set(_boost_DEBUG_NAMES
+    ${Boost_LIB_PREFIX}${Boost_NAMESPACE}_${COMPONENT}${_boost_COMPILER}${_boost_MULTITHREADED}${_boost_DEBUG_ABI_TAG}-${Boost_LIB_VERSION}
+    ${Boost_LIB_PREFIX}${Boost_NAMESPACE}_${COMPONENT}${_boost_COMPILER}${_boost_MULTITHREADED}${_boost_DEBUG_ABI_TAG}
+    ${Boost_LIB_PREFIX}${Boost_NAMESPACE}_${COMPONENT}${_boost_MULTITHREADED}${_boost_DEBUG_ABI_TAG}-${Boost_LIB_VERSION}
+    ${Boost_LIB_PREFIX}${Boost_NAMESPACE}_${COMPONENT}${_boost_MULTITHREADED}${_boost_DEBUG_ABI_TAG}
+    ${Boost_LIB_PREFIX}${Boost_NAMESPACE}_${COMPONENT}${_boost_MULTITHREADED}
+    ${Boost_LIB_PREFIX}${Boost_NAMESPACE}_${COMPONENT} )
+  if(_boost_STATIC_RUNTIME_WORKAROUND)
+    set(_boost_DEBUG_STATIC_ABI_TAG "-s${_boost_DEBUG_ABI_TAG}")
+    list(APPEND _boost_DEBUG_NAMES
+      ${Boost_LIB_PREFIX}${Boost_NAMESPACE}_${COMPONENT}${_boost_COMPILER}${_boost_MULTITHREADED}${_boost_DEBUG_STATIC_ABI_TAG}-${Boost_LIB_VERSION}
+      ${Boost_LIB_PREFIX}${Boost_NAMESPACE}_${COMPONENT}${_boost_COMPILER}${_boost_MULTITHREADED}${_boost_DEBUG_STATIC_ABI_TAG}
+      ${Boost_LIB_PREFIX}${Boost_NAMESPACE}_${COMPONENT}${_boost_MULTITHREADED}${_boost_DEBUG_STATIC_ABI_TAG}-${Boost_LIB_VERSION}
+      ${Boost_LIB_PREFIX}${Boost_NAMESPACE}_${COMPONENT}${_boost_MULTITHREADED}${_boost_DEBUG_STATIC_ABI_TAG} )
+  endif()
+  if(Boost_THREADAPI AND ${COMPONENT} STREQUAL "thread")
+     _Boost_PREPEND_LIST_WITH_THREADAPI(_boost_DEBUG_NAMES ${_boost_DEBUG_NAMES})
+  endif()
+  if(Boost_DEBUG)
+    message(STATUS "[ ${CMAKE_CURRENT_LIST_FILE}:${CMAKE_CURRENT_LIST_LINE} ] "
+                   "Searching for ${UPPERCOMPONENT}_LIBRARY_DEBUG: ${_boost_DEBUG_NAMES}")
+  endif()
+
+  # if Boost_LIBRARY_DIR_DEBUG is not defined,
+  # but Boost_LIBRARY_DIR_RELEASE is, look there first for DEBUG libs
+  if(NOT Boost_LIBRARY_DIR_DEBUG AND Boost_LIBRARY_DIR_RELEASE)
+    list(INSERT _boost_LIBRARY_SEARCH_DIRS_DEBUG 0 ${Boost_LIBRARY_DIR_RELEASE})
+  endif()
+
+  # Avoid passing backslashes to _Boost_FIND_LIBRARY due to macro re-parsing.
+  string(REPLACE "\\" "/" _boost_LIBRARY_SEARCH_DIRS_tmp "${_boost_LIBRARY_SEARCH_DIRS_DEBUG}")
+
+  _Boost_FIND_LIBRARY(Boost_${UPPERCOMPONENT}_LIBRARY_DEBUG DEBUG
+    NAMES ${_boost_DEBUG_NAMES}
+    HINTS ${_boost_LIBRARY_SEARCH_DIRS_tmp}
+    NAMES_PER_DIR
+    DOC "${_boost_docstring_debug}"
+    )
+
+  if(Boost_REALPATH)
+    _Boost_SWAP_WITH_REALPATH(Boost_${UPPERCOMPONENT}_LIBRARY_RELEASE "${_boost_docstring_release}")
+    _Boost_SWAP_WITH_REALPATH(Boost_${UPPERCOMPONENT}_LIBRARY_DEBUG   "${_boost_docstring_debug}"  )
+  endif()
+
+  _Boost_ADJUST_LIB_VARS(${UPPERCOMPONENT})
+
+endforeach()
+
+# Restore the original find library ordering
+if( Boost_USE_STATIC_LIBS )
+  set(CMAKE_FIND_LIBRARY_SUFFIXES ${_boost_ORIG_CMAKE_FIND_LIBRARY_SUFFIXES})
+endif()
+
+# ------------------------------------------------------------------------
+#  End finding boost libraries
+# ------------------------------------------------------------------------
+
+set(Boost_INCLUDE_DIRS ${Boost_INCLUDE_DIR})
+set(Boost_LIBRARY_DIRS)
+if(Boost_LIBRARY_DIR_RELEASE)
+  list(APPEND Boost_LIBRARY_DIRS ${Boost_LIBRARY_DIR_RELEASE})
+endif()
+if(Boost_LIBRARY_DIR_DEBUG)
+  list(APPEND Boost_LIBRARY_DIRS ${Boost_LIBRARY_DIR_DEBUG})
+endif()
+if(Boost_LIBRARY_DIRS)
+  list(REMOVE_DUPLICATES Boost_LIBRARY_DIRS)
+endif()
+
+# The above setting of Boost_FOUND was based only on the header files.
+# Update it for the requested component libraries.
+if(Boost_FOUND)
+  # The headers were found.  Check for requested component libs.
+  set(_boost_CHECKED_COMPONENT FALSE)
+  set(_Boost_MISSING_COMPONENTS "")
+  foreach(COMPONENT ${Boost_FIND_COMPONENTS})
+    string(TOUPPER ${COMPONENT} COMPONENT)
+    set(_boost_CHECKED_COMPONENT TRUE)
+    if(NOT Boost_${COMPONENT}_FOUND)
+      string(TOLOWER ${COMPONENT} COMPONENT)
+      list(APPEND _Boost_MISSING_COMPONENTS ${COMPONENT})
+    endif()
+  endforeach()
+
+  if(Boost_DEBUG)
+    message(STATUS "[ ${CMAKE_CURRENT_LIST_FILE}:${CMAKE_CURRENT_LIST_LINE} ] Boost_FOUND = ${Boost_FOUND}")
+  endif()
+
+  if (_Boost_MISSING_COMPONENTS)
+    set(Boost_FOUND 0)
+    # We were unable to find some libraries, so generate a sensible
+    # error message that lists the libraries we were unable to find.
+    set(Boost_ERROR_REASON
+      "${Boost_ERROR_REASON}\nCould not find the following")
+    if(Boost_USE_STATIC_LIBS)
+      set(Boost_ERROR_REASON "${Boost_ERROR_REASON} static")
+    endif()
+    set(Boost_ERROR_REASON
+      "${Boost_ERROR_REASON} Boost libraries:\n")
+    foreach(COMPONENT ${_Boost_MISSING_COMPONENTS})
+      set(Boost_ERROR_REASON
+        "${Boost_ERROR_REASON}        ${Boost_NAMESPACE}_${COMPONENT}\n")
+    endforeach()
+
+    list(LENGTH Boost_FIND_COMPONENTS Boost_NUM_COMPONENTS_WANTED)
+    list(LENGTH _Boost_MISSING_COMPONENTS Boost_NUM_MISSING_COMPONENTS)
+    if (${Boost_NUM_COMPONENTS_WANTED} EQUAL ${Boost_NUM_MISSING_COMPONENTS})
+      set(Boost_ERROR_REASON
+        "${Boost_ERROR_REASON}No Boost libraries were found. You may need to set BOOST_LIBRARYDIR to the directory containing Boost libraries or BOOST_ROOT to the location of Boost.")
+    else ()
+      set(Boost_ERROR_REASON
+        "${Boost_ERROR_REASON}Some (but not all) of the required Boost libraries were found. You may need to install these additional Boost libraries. Alternatively, set BOOST_LIBRARYDIR to the directory containing Boost libraries or BOOST_ROOT to the location of Boost.")
+    endif ()
+  endif ()
+
+  if( NOT Boost_LIBRARY_DIRS AND NOT _boost_CHECKED_COMPONENT )
+    # Compatibility Code for backwards compatibility with CMake
+    # 2.4's FindBoost module.
+
+    # Look for the boost library path.
+    # Note that the user may not have installed any libraries
+    # so it is quite possible the Boost_LIBRARY_DIRS may not exist.
+    set(_boost_LIB_DIR ${Boost_INCLUDE_DIR})
+
+    if("${_boost_LIB_DIR}" MATCHES "boost-[0-9]+")
+      get_filename_component(_boost_LIB_DIR ${_boost_LIB_DIR} PATH)
+    endif()
+
+    if("${_boost_LIB_DIR}" MATCHES "/include$")
+      # Strip off the trailing "/include" in the path.
+      get_filename_component(_boost_LIB_DIR ${_boost_LIB_DIR} PATH)
+    endif()
+
+    if(EXISTS "${_boost_LIB_DIR}/lib")
+      set(_boost_LIB_DIR ${_boost_LIB_DIR}/lib)
+    else()
+      if(EXISTS "${_boost_LIB_DIR}/stage/lib")
+        set(_boost_LIB_DIR ${_boost_LIB_DIR}/stage/lib)
+      else()
+        set(_boost_LIB_DIR "")
+      endif()
+    endif()
+
+    if(_boost_LIB_DIR AND EXISTS "${_boost_LIB_DIR}")
+      set(Boost_LIBRARY_DIRS ${_boost_LIB_DIR})
+    endif()
+
+  endif()
+else()
+  # Boost headers were not found so no components were found.
+  foreach(COMPONENT ${Boost_FIND_COMPONENTS})
+    string(TOUPPER ${COMPONENT} UPPERCOMPONENT)
+    set(Boost_${UPPERCOMPONENT}_FOUND 0)
+  endforeach()
+endif()
+
+# ------------------------------------------------------------------------
+#  Notification to end user about what was found
+# ------------------------------------------------------------------------
+
+set(Boost_LIBRARIES "")
+if(Boost_FOUND)
+  if(NOT Boost_FIND_QUIETLY)
+    message(STATUS "Boost version: ${Boost_MAJOR_VERSION}.${Boost_MINOR_VERSION}.${Boost_SUBMINOR_VERSION}")
+    if(Boost_FIND_COMPONENTS)
+      message(STATUS "Found the following Boost libraries:")
+    endif()
+  endif()
+  foreach( COMPONENT  ${Boost_FIND_COMPONENTS} )
+    string( TOUPPER ${COMPONENT} UPPERCOMPONENT )
+    if( Boost_${UPPERCOMPONENT}_FOUND )
+      if(NOT Boost_FIND_QUIETLY)
+        message (STATUS "  ${COMPONENT}")
+      endif()
+      list(APPEND Boost_LIBRARIES ${Boost_${UPPERCOMPONENT}_LIBRARY})
+    endif()
+  endforeach()
+else()
+  if(Boost_FIND_REQUIRED)
+    message(SEND_ERROR "Unable to find the requested Boost libraries.\n${Boost_ERROR_REASON}")
+  else()
+    if(NOT Boost_FIND_QUIETLY)
+      # we opt not to automatically output Boost_ERROR_REASON here as
+      # it could be quite lengthy and somewhat imposing in its requests
+      # Since Boost is not always a required dependency we'll leave this
+      # up to the end-user.
+      if(Boost_DEBUG OR Boost_DETAILED_FAILURE_MSG)
+        message(STATUS "Could NOT find Boost\n${Boost_ERROR_REASON}")
+      else()
+        message(STATUS "Could NOT find Boost")
+      endif()
+    endif()
+  endif()
+endif()
+
+# Configure display of cache entries in GUI.
+foreach(v BOOSTROOT BOOST_ROOT ${_Boost_VARS_INC} ${_Boost_VARS_LIB})
+  get_property(_type CACHE ${v} PROPERTY TYPE)
+  if(_type)
+    set_property(CACHE ${v} PROPERTY ADVANCED 1)
+    if("x${_type}" STREQUAL "xUNINITIALIZED")
+      if("x${v}" STREQUAL "xBoost_ADDITIONAL_VERSIONS")
+        set_property(CACHE ${v} PROPERTY TYPE STRING)
+      else()
+        set_property(CACHE ${v} PROPERTY TYPE PATH)
+      endif()
+    endif()
+  endif()
+endforeach()
+
+# Record last used values of input variables so we can
+# detect on the next run if the user changed them.
+foreach(v
+    ${_Boost_VARS_INC} ${_Boost_VARS_LIB}
+    ${_Boost_VARS_DIR} ${_Boost_VARS_NAME}
+    )
+  if(DEFINED ${v})
+    set(_${v}_LAST "${${v}}" CACHE INTERNAL "Last used ${v} value.")
+  else()
+    unset(_${v}_LAST CACHE)
+  endif()
+endforeach()
+
+# Maintain a persistent list of components requested anywhere since
+# the last flush.
+set(_Boost_COMPONENTS_SEARCHED "${_Boost_COMPONENTS_SEARCHED}")
+list(APPEND _Boost_COMPONENTS_SEARCHED ${Boost_FIND_COMPONENTS})
+list(REMOVE_DUPLICATES _Boost_COMPONENTS_SEARCHED)
+list(SORT _Boost_COMPONENTS_SEARCHED)
+set(_Boost_COMPONENTS_SEARCHED "${_Boost_COMPONENTS_SEARCHED}"
+  CACHE INTERNAL "Components requested for this build tree.")

--- a/cmake/FindYamlCpp.cmake
+++ b/cmake/FindYamlCpp.cmake
@@ -1,0 +1,50 @@
+# Locate yaml-cpp
+#
+# This module defines
+#  YAMLCPP_FOUND, if false, do not try to link to yaml-cpp
+#  YAMLCPP_LIBRARY, where to find yaml-cpp
+#  YAMLCPP_INCLUDE_DIR, where to find yaml.h
+#
+# By default, the dynamic libraries of yaml-cpp will be found. To find the static ones instead,
+# you must set the YAMLCPP_STATIC_LIBRARY variable to TRUE before calling find_package(YamlCpp ...).
+#
+# If yaml-cpp is not installed in a standard path, you can use the YAMLCPP_DIR CMake variable
+# to tell CMake where yaml-cpp is.
+
+# attempt to find static library first if this is set
+if(YAMLCPP_STATIC_LIBRARY)
+    set(YAMLCPP_STATIC libyaml-cpp.a)
+endif()
+
+# find the yaml-cpp include directory
+find_path(YAMLCPP_INCLUDE_DIR yaml-cpp/yaml.h
+          PATH_SUFFIXES include
+          PATHS
+          ~/Library/Frameworks/yaml-cpp/include/
+          /Library/Frameworks/yaml-cpp/include/
+          /usr/local/include/
+          /usr/include/
+          /sw/yaml-cpp/         # Fink
+          /opt/local/yaml-cpp/  # DarwinPorts
+          /opt/csw/yaml-cpp/    # Blastwave
+          /opt/yaml-cpp/
+          ${YAMLCPP_DIR}/include/)
+
+# find the yaml-cpp library
+find_library(YAMLCPP_LIBRARY
+             NAMES ${YAMLCPP_STATIC} yaml-cpp
+             PATH_SUFFIXES lib64 lib
+             PATHS ~/Library/Frameworks
+                    /Library/Frameworks
+                    /usr/local
+                    /usr
+                    /sw
+                    /opt/local
+                    /opt/csw
+                    /opt
+                    ${YAMLCPP_DIR}/lib)
+
+# handle the QUIETLY and REQUIRED arguments and set YAMLCPP_FOUND to TRUE if all listed variables are TRUE
+include(FindPackageHandleStandardArgs)
+FIND_PACKAGE_HANDLE_STANDARD_ARGS(YAMLCPP DEFAULT_MSG YAMLCPP_INCLUDE_DIR YAMLCPP_LIBRARY)
+mark_as_advanced(YAMLCPP_INCLUDE_DIR YAMLCPP_LIBRARY)

--- a/scripts/test.py
+++ b/scripts/test.py
@@ -20,10 +20,12 @@ def printDiff(str1,str2):
    print ''.join(diff),
 
 def runTest():
-   cc, src, sas_plugin, checkers, refOutputName = sys.argv[1:]
+   cc, src, sas_plugin, checkers, refOutputName, configuration_yaml = sys.argv[1:]
    basePath = getBasePath(sas_plugin)
 
    compile_env = {"SA_PLUGIN": sas_plugin, "SA_CHECKERS": checkers}
+   if configuration_yaml != "":
+      compile_env["SA_CONFIGURATION"] = configuration_yaml
    process = subprocess.Popen([cc, "-c", "-std=c++11", src], stderr=subprocess.PIPE, env=compile_env)
 
    analyze_output = process.communicate()[1]

--- a/src/BlackWhiteListCheckerDisabler.cpp
+++ b/src/BlackWhiteListCheckerDisabler.cpp
@@ -1,0 +1,159 @@
+#include <fstream>
+#include "BlackWhiteListCheckerDisabler.h"
+
+BlackWhiteListCheckerDisabler::BlackWhiteListCheckerDisabler(const clang::Decl *D,
+                                                             const char *checker,
+                                                             clang::ento::BugReporter &BR,
+                                                             const clang::SourceLocation &sLoc)
+   : sLoc(sLoc), checker(checker)
+{
+   auto &mgr = BR.getSourceManager();
+   relPath = mgr.getFilename(sLoc);
+   auto *DC = D->getDeclContext();
+   WalkDeclContext(DC);
+}
+
+BlackWhiteListCheckerDisabler::BlackWhiteListCheckerDisabler(clang::ento::CheckerContext &C,
+                                                             const char *checker,
+                                                             clang::ento::BugReporter &BR,
+                                                             const clang::SourceLocation &sLoc)
+   : sLoc(sLoc), checker(checker)
+{
+   auto &mgr = BR.getSourceManager();
+   relPath = mgr.getFilename(sLoc);
+   const clang::LocationContext *LC = C.getLocationContext();
+   auto *D = LC->getDecl();
+   auto *DC = D->getDeclContext();
+   WalkDeclContext(DC);
+}
+
+void BlackWhiteListCheckerDisabler::WalkDeclContext(const clang::DeclContext *DC){
+   auto *enclosingNamespaceContext = DC->getEnclosingNamespaceContext();
+
+   if(enclosingNamespaceContext->isNamespace())
+   {
+      auto *NNDC = clang::NamespaceDecl::castFromDeclContext(enclosingNamespaceContext);
+      namespace_name = NNDC->getQualifiedNameAsString();
+   }
+   auto *traversalContext = DC;
+   while(!traversalContext->isTranslationUnit())
+   {
+      if(!traversalContext->isRecord()){
+         traversalContext = traversalContext->getParent();
+         continue;
+      }
+      const clang::RecordDecl *RD = clang::cast<clang::RecordDecl>(traversalContext);
+      if(RD->isClass())
+         class_name = RD->getNameAsString();
+      else if(RD->isStruct())
+         struct_name = RD->getNameAsString();
+      if((!struct_name.empty()) && (!class_name.empty())) break;
+      traversalContext = traversalContext->getParent();
+   }
+}
+
+bool BlackWhiteListCheckerDisabler::PathWildCardMatch(const YAML::Node &pathWildCardList,
+                                                      const std::string &matchString) const {
+   if(matchString.empty()) return true;
+   if(pathWildCardList && pathWildCardList.Type() == YAML::NodeType::Sequence)
+   {
+      for(std::size_t listIndex = 0;
+          listIndex < pathWildCardList.size();
+          ++listIndex){
+         if (fnmatch(pathWildCardList[listIndex].as<std::string>().c_str(),
+                     matchString.c_str(),
+                     FNM_PATHNAME) == 0)
+            return true;
+         }
+      return false;
+   }
+   else return true;
+}
+
+bool BlackWhiteListCheckerDisabler::RegexMatch(const YAML::Node &regexList,
+                                               const std::string &matchString) const {
+   if(matchString.empty()) return true;
+   if(regexList && regexList.Type() == YAML::NodeType::Sequence)
+   {
+      for(std::size_t regexListIndex = 0;
+          regexListIndex < regexList.size();
+          ++regexListIndex){
+         std::regex regex(regexList[regexListIndex].as<std::string>());
+         if(std::regex_match(matchString, regex))
+            return true;
+      }
+      return false;
+   }
+   else return true;
+}
+
+bool BlackWhiteListCheckerDisabler::PrefixMatch(const YAML::Node &prefixList,
+                                                const std::string &matchString) const{
+   if(matchString.empty()) return true;
+   if(prefixList && prefixList.Type() == YAML::NodeType::Sequence)
+   {
+      for(std::size_t prefixListIndex = 0;
+          prefixListIndex < prefixList.size();
+          ++prefixListIndex)
+      {
+         std::string prefixInList = prefixList[prefixListIndex].as<std::string>();
+         if(std::equal(prefixInList.begin(), prefixInList.end(), matchString.begin()))
+            return true;
+      }
+      return false;
+   }
+   else return true;
+}
+
+bool BlackWhiteListCheckerDisabler::ParseBlackWhiteField(const YAML::Node &bwConfig) const{
+   if(bwConfig && bwConfig.Type() == YAML::NodeType::Scalar){
+      bool bw = (bwConfig.as<std::string>() == "W") ? true : false;
+         return bw;
+   }
+   return false;
+}
+
+bool BlackWhiteListCheckerDisabler::CheckBlackWhiteListConfiguration() const{
+   // scan if SA_CONFIGURATION environment variable is set
+   std::string sas_configuration_path;
+   if(const char* env_p = std::getenv("SA_CONFIGURATION"))
+   {
+      sas_configuration_path = env_p;
+   }
+   // if SA_CONFIGURATION is not set we will scan the .sas.yaml under working directory
+   // if we cannot find configuration yaml, then we fire the checker by default
+   else sas_configuration_path = ".sas.yaml";
+   std::ifstream config_file(sas_configuration_path);
+   if (!config_file.good()) {
+        config_file.close();
+        return false;
+   }
+   else config_file.close();
+   YAML::Node config = YAML::LoadFile(sas_configuration_path)["CONFIGURATION"];
+
+   if(!config) return false;
+
+   // parse the configuration file
+   for (std::size_t config_i = 0; config_i < config.size(); ++config_i) {
+      bool path_match=PathWildCardMatch(config[config_i]["FILE_PATH"], relPath.str()),
+         namespace_match=RegexMatch(config[config_i]["NAMESPACE"], namespace_name),
+         struct_match=RegexMatch(config[config_i]["STRUCT"], struct_name),
+         class_match=RegexMatch(config[config_i]["CLASS"], class_name);
+
+      bool match = path_match && namespace_match && struct_match && class_match;
+      //if all path/namespace/class/struct are matched, we then check the b/w and decide whether we fire
+      if (match)
+      {
+         bool blackWhite = ParseBlackWhiteField(config[config_i]["B/W"]),
+            checkerMatch = PrefixMatch(config[config_i]["CHECKER"], checker),
+            ifLaunch = (checkerMatch) ? blackWhite : !blackWhite;
+         if(!ifLaunch) return true;
+      }
+   }
+   return false;
+}
+
+bool BlackWhiteListCheckerDisabler::isDisabled()
+{
+   return CheckBlackWhiteListConfiguration();
+}

--- a/src/BlackWhiteListCheckerDisabler.h
+++ b/src/BlackWhiteListCheckerDisabler.h
@@ -1,0 +1,43 @@
+/*
+  A black/white List checker disabler
+*/
+
+#ifndef BLACK_WHITE_LIST_CHECKER_DISABLER_H
+#define BLACK_WHITE_LIST_CHECKER_DISABLER_H
+
+#include <clang/StaticAnalyzer/Core/BugReporter/BugReporter.h>
+#include <clang/StaticAnalyzer/Core/PathSensitive/CheckerContext.h>
+#include <fnmatch.h>
+#include <yaml-cpp/yaml.h>
+#include <regex>
+
+class BlackWhiteListCheckerDisabler {
+   bool PathWildCardMatch(const YAML::Node &, const std::string &) const;
+   bool RegexMatch(const YAML::Node &, const std::string &) const;
+   bool PrefixMatch(const YAML::Node &, const std::string &) const;
+   bool ParseBlackWhiteField(const YAML::Node &) const;
+   bool CheckBlackWhiteListConfiguration() const;
+   void WalkDeclContext(const clang::DeclContext *);
+
+   const clang::SourceLocation sLoc;
+   std::string checker;
+   std::string struct_name;
+   std::string class_name;
+   std::string namespace_name;
+   llvm::StringRef relPath;
+
+public:
+   BlackWhiteListCheckerDisabler(const clang::Decl *,
+                                 const char *,
+                                 clang::ento::BugReporter &,
+                                 const clang::SourceLocation &);
+
+   BlackWhiteListCheckerDisabler(clang::ento::CheckerContext &C,
+                                 const char *checker,
+                                 clang::ento::BugReporter &BR,
+                                 const clang::SourceLocation &sLoc);
+   bool isDisabled();
+};
+
+
+#endif

--- a/src/ClangSasCheckerPluginRegister.cpp
+++ b/src/ClangSasCheckerPluginRegister.cpp
@@ -62,6 +62,7 @@ extern "C" void clang_registerCheckers(clang::ento::CheckerRegistry& registry)
    {
       using namespace sas::CodingConventions::General;
       AddToRegistry<NoUsingNamespaceInHeaders>(registry);
+      AddToRegistry<StdPrintoutsChecker>(registry);
    }
 
    // ROOT Coding Conventions

--- a/src/CodingConventions/General/Rules.h
+++ b/src/CodingConventions/General/Rules.h
@@ -1,1 +1,2 @@
 #include "UsingNamespace.h"
+#include "StdPrintoutsChecker.h"

--- a/src/CodingConventions/General/StdPrintoutsChecker.cpp
+++ b/src/CodingConventions/General/StdPrintoutsChecker.cpp
@@ -1,0 +1,31 @@
+#include "StdPrintoutsChecker.h"
+namespace sas {
+   namespace CodingConventions {
+      namespace General {
+         void StdPrintoutsChecker::checkPreStmt(const clang::CallExpr *E,
+                                                clang::ento::CheckerContext &C) const
+         {
+            for(clang::Stmt::const_child_iterator I = E->child_begin(), F = E->child_end();
+                I != F;
+                ++I)
+            {
+               const clang::Expr *child = llvm::dyn_cast<clang::Expr>(*I);
+               if(!child) continue;
+               if(llvm::isa<clang::DeclRefExpr>(child->IgnoreImpCasts())) {
+                  const clang::NamedDecl *ND =
+                     llvm::cast<clang::DeclRefExpr>(child->IgnoreImpCasts())->getFoundDecl();
+                  std::string identifierName = ND->getNameAsString();
+                  if(identifierName == "cerr" ||
+                     identifierName == "cout" ||
+                     identifierName == "printf")
+                  {
+                     const char* msg = "[sas.CodingConventions.General.StdPrintouts] Big software systems always come with an advanced logging infrastructure. The usage of printouts may be considered an issue.";
+                     Report(E, msg, C);
+                  }
+               }
+
+            }
+         }
+      } // end namespace general
+   } // end namespace CodingConventions
+} // end namespace sas

--- a/src/CodingConventions/General/StdPrintoutsChecker.h
+++ b/src/CodingConventions/General/StdPrintoutsChecker.h
@@ -1,0 +1,34 @@
+//==-- StdPrintoutsChecker.h - Checks for debugging cout,cerr,printf printouts -- C++ -*--==//
+//
+// by Zhengyang Liu [ zhengyangl@hotmail.com ]
+//
+//===------------------------------------------------------------------------------------===//
+
+#include "SasChecker.h"
+
+#ifndef STD_PRINTOUTS_CHECKER_H
+#define STD_PRINTOUTS_CHECKER_H
+
+#include "SasChecker.h"
+
+namespace sas {
+   namespace CodingConventions {
+      namespace General {
+         class StdPrintoutsTraits : public CommonCheckerTraits {
+         public:
+            static constexpr const char *Name = "sas.CodingConventions.General.StdPrintouts";
+            static constexpr const char *Description = "Big software systems always come with an advanced logging infrastructure. The usage of printouts may be considered an issue.";
+         };
+
+         class StdPrintoutsChecker :
+            public SasChecker <StdPrintoutsTraits,
+                               clang::ento::check::PreStmt<clang::CallExpr>>
+         {
+         public:
+            void checkPreStmt(const clang::CallExpr *,
+                              clang::ento::CheckerContext &) const;
+         };
+      }
+   }
+}
+#endif

--- a/test/BWList/Class/.sas.yaml
+++ b/test/BWList/Class/.sas.yaml
@@ -1,0 +1,9 @@
+CONFIGURATION:
+  - FILE_PATH: ["WhiteList/*.cpp"]
+    CLASS: ["TA.*"]
+    CHECKER: ["sas.CodingConventions.ROOT.RN3"]
+    B/W: W
+  - FILE_PATH: ["BlackList/*.cpp"]
+    CLASS: ["TA.*"]
+    CHECKER: ["sas.CodingConventions.ROOT.RN3"]
+    B/W: B

--- a/test/BWList/Class/BlackList/match.cpp
+++ b/test/BWList/Class/BlackList/match.cpp
@@ -1,0 +1,14 @@
+class TApple
+{
+   typedef int time;  // RN3 bug
+   typedef int time_t;
+   enum EmyEnum{};
+   enum myEnum{}; //RN6 bug
+};
+class TBoy
+{
+   typedef int time;  // RN3 bug
+   typedef int time_t;
+   enum EmyEnum{};
+   enum myEnum{}; //RN6 bug
+};

--- a/test/BWList/Class/BlackList/match.ref
+++ b/test/BWList/Class/BlackList/match.ref
@@ -1,0 +1,13 @@
+BlackList/match.cpp:6:4: warning: [sas.CodingConventions.ROOT.RN6] RN6: Enumerations names must start with "E"
+   enum myEnum{}; //RN6 bug
+   ^
+BlackList/match.cpp:6:4: note: [sas.CodingConventions.ROOT.RN6] RN6: Enumerations names must start with "E"
+BlackList/match.cpp:10:4: warning: [sas.CodingConventions.ROOT.RN3] RN3: Typedefs and aliases names must end with a "_t"
+   typedef int time;  // RN3 bug
+   ^
+BlackList/match.cpp:10:4: note: [sas.CodingConventions.ROOT.RN3] RN3: Typedefs and aliases names must end with a "_t"
+BlackList/match.cpp:13:4: warning: [sas.CodingConventions.ROOT.RN6] RN6: Enumerations names must start with "E"
+   enum myEnum{}; //RN6 bug
+   ^
+BlackList/match.cpp:13:4: note: [sas.CodingConventions.ROOT.RN6] RN6: Enumerations names must start with "E"
+3 warnings generated.

--- a/test/BWList/Class/WhiteList/match.cpp
+++ b/test/BWList/Class/WhiteList/match.cpp
@@ -1,0 +1,14 @@
+class TApple
+{
+   typedef int time;  // RN3 bug
+   typedef int time_t;
+   enum EmyEnum{};
+   enum myEnum{}; //RN6 bug
+};
+class TBoy
+{
+   typedef int time;  // RN3 bug
+   typedef int time_t;
+   enum EmyEnum{};
+   enum myEnum{}; //RN6 bug
+};

--- a/test/BWList/Class/WhiteList/match.ref
+++ b/test/BWList/Class/WhiteList/match.ref
@@ -1,0 +1,13 @@
+WhiteList/match.cpp:3:4: warning: [sas.CodingConventions.ROOT.RN3] RN3: Typedefs and aliases names must end with a "_t"
+   typedef int time;  // RN3 bug
+   ^
+WhiteList/match.cpp:3:4: note: [sas.CodingConventions.ROOT.RN3] RN3: Typedefs and aliases names must end with a "_t"
+WhiteList/match.cpp:10:4: warning: [sas.CodingConventions.ROOT.RN3] RN3: Typedefs and aliases names must end with a "_t"
+   typedef int time;  // RN3 bug
+   ^
+WhiteList/match.cpp:10:4: note: [sas.CodingConventions.ROOT.RN3] RN3: Typedefs and aliases names must end with a "_t"
+WhiteList/match.cpp:13:4: warning: [sas.CodingConventions.ROOT.RN6] RN6: Enumerations names must start with "E"
+   enum myEnum{}; //RN6 bug
+   ^
+WhiteList/match.cpp:13:4: note: [sas.CodingConventions.ROOT.RN6] RN6: Enumerations names must start with "E"
+3 warnings generated.

--- a/test/BWList/FilePath/.sas.yaml
+++ b/test/BWList/FilePath/.sas.yaml
@@ -1,0 +1,7 @@
+CONFIGURATION:
+  - FILE_PATH: ["WhiteList/mat*.cpp"]
+    CHECKER: ["sas.CodingConventions.ROOT.RN3"]
+    B/W: W
+  - FILE_PATH: ["BlackList/mat*.cpp"]
+    CHECKER: ["sas.CodingConventions.ROOT.RN3"]
+    B/W: B

--- a/test/BWList/FilePath/BlackList/match.cpp
+++ b/test/BWList/FilePath/BlackList/match.cpp
@@ -1,0 +1,5 @@
+typedef int time_t;
+typedef int time;  // RN3 bug
+class TMyClass{};
+class Tyourclass{}; //RN4 bug
+class myClass{}; // RN4 bug

--- a/test/BWList/FilePath/BlackList/match.ref
+++ b/test/BWList/FilePath/BlackList/match.ref
@@ -1,0 +1,9 @@
+BlackList/match.cpp:4:1: warning: [sas.CodingConventions.ROOT.RN4] RN4: Ill formed class/struct name. The first letter must be a "T", the second uppercase and the third lowercase
+class Tyourclass{}; //RN4 bug
+^
+BlackList/match.cpp:4:1: note: [sas.CodingConventions.ROOT.RN4] RN4: Ill formed class/struct name. The first letter must be a "T", the second uppercase and the third lowercase
+BlackList/match.cpp:5:1: warning: [sas.CodingConventions.ROOT.RN4] RN4: Ill formed class/struct name. The first letter must be a "T", the second uppercase and the third lowercase
+class myClass{}; // RN4 bug
+^
+BlackList/match.cpp:5:1: note: [sas.CodingConventions.ROOT.RN4] RN4: Ill formed class/struct name. The first letter must be a "T", the second uppercase and the third lowercase
+2 warnings generated.

--- a/test/BWList/FilePath/BlackList/unmatch.cpp
+++ b/test/BWList/FilePath/BlackList/unmatch.cpp
@@ -1,0 +1,5 @@
+typedef int time_t;
+typedef int time;  // RN3 bug
+class TMyClass{};
+class Tyourclass{}; //RN4 bug
+class myClass{}; // RN4 bug

--- a/test/BWList/FilePath/BlackList/unmatch.ref
+++ b/test/BWList/FilePath/BlackList/unmatch.ref
@@ -1,0 +1,13 @@
+BlackList/unmatch.cpp:2:1: warning: [sas.CodingConventions.ROOT.RN3] RN3: Typedefs and aliases names must end with a "_t"
+typedef int time;  // RN3 bug
+^
+BlackList/unmatch.cpp:2:1: note: [sas.CodingConventions.ROOT.RN3] RN3: Typedefs and aliases names must end with a "_t"
+BlackList/unmatch.cpp:4:1: warning: [sas.CodingConventions.ROOT.RN4] RN4: Ill formed class/struct name. The first letter must be a "T", the second uppercase and the third lowercase
+class Tyourclass{}; //RN4 bug
+^
+BlackList/unmatch.cpp:4:1: note: [sas.CodingConventions.ROOT.RN4] RN4: Ill formed class/struct name. The first letter must be a "T", the second uppercase and the third lowercase
+BlackList/unmatch.cpp:5:1: warning: [sas.CodingConventions.ROOT.RN4] RN4: Ill formed class/struct name. The first letter must be a "T", the second uppercase and the third lowercase
+class myClass{}; // RN4 bug
+^
+BlackList/unmatch.cpp:5:1: note: [sas.CodingConventions.ROOT.RN4] RN4: Ill formed class/struct name. The first letter must be a "T", the second uppercase and the third lowercase
+3 warnings generated.

--- a/test/BWList/FilePath/WhiteList/match.cpp
+++ b/test/BWList/FilePath/WhiteList/match.cpp
@@ -1,0 +1,5 @@
+typedef int time_t;
+typedef int time;  // RN3 bug
+class TMyClass{};
+class Tyourclass{}; //RN4 bug
+class myClass{}; // RN4 bug

--- a/test/BWList/FilePath/WhiteList/match.ref
+++ b/test/BWList/FilePath/WhiteList/match.ref
@@ -1,0 +1,5 @@
+WhiteList/match.cpp:2:1: warning: [sas.CodingConventions.ROOT.RN3] RN3: Typedefs and aliases names must end with a "_t"
+typedef int time;  // RN3 bug
+^
+WhiteList/match.cpp:2:1: note: [sas.CodingConventions.ROOT.RN3] RN3: Typedefs and aliases names must end with a "_t"
+1 warning generated.

--- a/test/BWList/FilePath/WhiteList/unmatch.cpp
+++ b/test/BWList/FilePath/WhiteList/unmatch.cpp
@@ -1,0 +1,5 @@
+typedef int time_t;
+typedef int time;  // RN3 bug
+class TMyClass{};
+class Tyourclass{}; //RN4 bug
+class myClass{}; // RN4 bug

--- a/test/BWList/FilePath/WhiteList/unmatch.ref
+++ b/test/BWList/FilePath/WhiteList/unmatch.ref
@@ -1,0 +1,13 @@
+WhiteList/unmatch.cpp:2:1: warning: [sas.CodingConventions.ROOT.RN3] RN3: Typedefs and aliases names must end with a "_t"
+typedef int time;  // RN3 bug
+^
+WhiteList/unmatch.cpp:2:1: note: [sas.CodingConventions.ROOT.RN3] RN3: Typedefs and aliases names must end with a "_t"
+WhiteList/unmatch.cpp:4:1: warning: [sas.CodingConventions.ROOT.RN4] RN4: Ill formed class/struct name. The first letter must be a "T", the second uppercase and the third lowercase
+class Tyourclass{}; //RN4 bug
+^
+WhiteList/unmatch.cpp:4:1: note: [sas.CodingConventions.ROOT.RN4] RN4: Ill formed class/struct name. The first letter must be a "T", the second uppercase and the third lowercase
+WhiteList/unmatch.cpp:5:1: warning: [sas.CodingConventions.ROOT.RN4] RN4: Ill formed class/struct name. The first letter must be a "T", the second uppercase and the third lowercase
+class myClass{}; // RN4 bug
+^
+WhiteList/unmatch.cpp:5:1: note: [sas.CodingConventions.ROOT.RN4] RN4: Ill formed class/struct name. The first letter must be a "T", the second uppercase and the third lowercase
+3 warnings generated.

--- a/test/BWList/Misc/configuration.yaml
+++ b/test/BWList/Misc/configuration.yaml
@@ -1,0 +1,5 @@
+CONFIGURATION:
+  - FILE_PATH: ["match.cpp"]
+    CHECKER: ["sas.CodingConventions.ROOT.RN3"]
+    B/W: B
+

--- a/test/BWList/Misc/match.cpp
+++ b/test/BWList/Misc/match.cpp
@@ -1,0 +1,3 @@
+
+typedef int time;  // bug
+typedef int time_t;

--- a/test/BWList/Namespace/.sas.yaml
+++ b/test/BWList/Namespace/.sas.yaml
@@ -1,0 +1,9 @@
+CONFIGURATION:
+  - FILE_PATH: ["WhiteList/*.cpp"]
+    NAMESPACE: ["outside::inside"]
+    CHECKER: ["sas.CodingConventions.ROOT.RN3"]
+    B/W: W
+  - FILE_PATH: ["BlackList/*.cpp"]
+    NAMESPACE: ["outside::inside"]
+    CHECKER: ["sas.CodingConventions.ROOT.RN3"]
+    B/W: B

--- a/test/BWList/Namespace/BlackList/match.cpp
+++ b/test/BWList/Namespace/BlackList/match.cpp
@@ -1,0 +1,19 @@
+namespace outside{
+   namespace inside{
+      typedef int time;  // RN3 bug
+      typedef int time_t;
+      class TMyClass{};
+      class Tyourclass{}; //RN4 bug
+      class myClass{}; // RN4 bug
+   }
+}
+
+namespace wrong_outside{
+   namespace inside{
+      typedef int time;  // RN3 bug
+      typedef int time_t;
+      class TMyClass{};
+      class Tyourclass{}; //RN4 bug
+      class myClass{}; // RN4 bug
+   }
+}

--- a/test/BWList/Namespace/BlackList/match.ref
+++ b/test/BWList/Namespace/BlackList/match.ref
@@ -1,0 +1,21 @@
+BlackList/match.cpp:6:7: warning: [sas.CodingConventions.ROOT.RN4] RN4: Ill formed class/struct name. The first letter must be a "T", the second uppercase and the third lowercase
+      class Tyourclass{}; //RN4 bug
+      ^
+BlackList/match.cpp:6:7: note: [sas.CodingConventions.ROOT.RN4] RN4: Ill formed class/struct name. The first letter must be a "T", the second uppercase and the third lowercase
+BlackList/match.cpp:7:7: warning: [sas.CodingConventions.ROOT.RN4] RN4: Ill formed class/struct name. The first letter must be a "T", the second uppercase and the third lowercase
+      class myClass{}; // RN4 bug
+      ^
+BlackList/match.cpp:7:7: note: [sas.CodingConventions.ROOT.RN4] RN4: Ill formed class/struct name. The first letter must be a "T", the second uppercase and the third lowercase
+BlackList/match.cpp:13:7: warning: [sas.CodingConventions.ROOT.RN3] RN3: Typedefs and aliases names must end with a "_t"
+      typedef int time;  // RN3 bug
+      ^
+BlackList/match.cpp:13:7: note: [sas.CodingConventions.ROOT.RN3] RN3: Typedefs and aliases names must end with a "_t"
+BlackList/match.cpp:16:7: warning: [sas.CodingConventions.ROOT.RN4] RN4: Ill formed class/struct name. The first letter must be a "T", the second uppercase and the third lowercase
+      class Tyourclass{}; //RN4 bug
+      ^
+BlackList/match.cpp:16:7: note: [sas.CodingConventions.ROOT.RN4] RN4: Ill formed class/struct name. The first letter must be a "T", the second uppercase and the third lowercase
+BlackList/match.cpp:17:7: warning: [sas.CodingConventions.ROOT.RN4] RN4: Ill formed class/struct name. The first letter must be a "T", the second uppercase and the third lowercase
+      class myClass{}; // RN4 bug
+      ^
+BlackList/match.cpp:17:7: note: [sas.CodingConventions.ROOT.RN4] RN4: Ill formed class/struct name. The first letter must be a "T", the second uppercase and the third lowercase
+5 warnings generated.

--- a/test/BWList/Namespace/WhiteList/match.cpp
+++ b/test/BWList/Namespace/WhiteList/match.cpp
@@ -1,0 +1,19 @@
+namespace outside{
+   namespace inside{
+      typedef int time;  // RN3 bug
+      typedef int time_t;
+      class TMyClass{};
+      class Tyourclass{}; //RN4 bug
+      class myClass{}; // RN4 bug
+   }
+}
+
+namespace wrong_outside{
+   namespace inside{
+      typedef int time;  // RN3 bug
+      typedef int time_t;
+      class TMyClass{};
+      class Tyourclass{}; //RN4 bug
+      class myClass{}; // RN4 bug
+   }
+}

--- a/test/BWList/Namespace/WhiteList/match.ref
+++ b/test/BWList/Namespace/WhiteList/match.ref
@@ -1,0 +1,17 @@
+WhiteList/match.cpp:3:7: warning: [sas.CodingConventions.ROOT.RN3] RN3: Typedefs and aliases names must end with a "_t"
+      typedef int time;  // RN3 bug
+      ^
+WhiteList/match.cpp:3:7: note: [sas.CodingConventions.ROOT.RN3] RN3: Typedefs and aliases names must end with a "_t"
+WhiteList/match.cpp:13:7: warning: [sas.CodingConventions.ROOT.RN3] RN3: Typedefs and aliases names must end with a "_t"
+      typedef int time;  // RN3 bug
+      ^
+WhiteList/match.cpp:13:7: note: [sas.CodingConventions.ROOT.RN3] RN3: Typedefs and aliases names must end with a "_t"
+WhiteList/match.cpp:16:7: warning: [sas.CodingConventions.ROOT.RN4] RN4: Ill formed class/struct name. The first letter must be a "T", the second uppercase and the third lowercase
+      class Tyourclass{}; //RN4 bug
+      ^
+WhiteList/match.cpp:16:7: note: [sas.CodingConventions.ROOT.RN4] RN4: Ill formed class/struct name. The first letter must be a "T", the second uppercase and the third lowercase
+WhiteList/match.cpp:17:7: warning: [sas.CodingConventions.ROOT.RN4] RN4: Ill formed class/struct name. The first letter must be a "T", the second uppercase and the third lowercase
+      class myClass{}; // RN4 bug
+      ^
+WhiteList/match.cpp:17:7: note: [sas.CodingConventions.ROOT.RN4] RN4: Ill formed class/struct name. The first letter must be a "T", the second uppercase and the third lowercase
+4 warnings generated.

--- a/test/BWList/Struct/.sas.yaml
+++ b/test/BWList/Struct/.sas.yaml
@@ -1,0 +1,9 @@
+CONFIGURATION:
+  - FILE_PATH: ["WhiteList/*.cpp"]
+    STRUCT: ["TA.*"]
+    CHECKER: ["sas.CodingConventions.ROOT.RN3"]
+    B/W: W
+  - FILE_PATH: ["BlackList/*.cpp"]
+    STRUCT: ["TA.*"]
+    CHECKER: ["sas.CodingConventions.ROOT.RN3"]
+    B/W: B

--- a/test/BWList/Struct/BlackList/match.cpp
+++ b/test/BWList/Struct/BlackList/match.cpp
@@ -1,0 +1,14 @@
+struct TApple
+{
+   typedef int time;  // RN3 bug
+   typedef int time_t;
+   enum EmyEnum{};
+   enum myEnum{}; //RN6 bug
+};
+struct TBoy
+{
+   typedef int time;  // RN3 bug
+   typedef int time_t;
+   enum EmyEnum{};
+   enum myEnum{}; //RN6 bug
+};

--- a/test/BWList/Struct/BlackList/match.ref
+++ b/test/BWList/Struct/BlackList/match.ref
@@ -1,0 +1,13 @@
+BlackList/match.cpp:6:4: warning: [sas.CodingConventions.ROOT.RN6] RN6: Enumerations names must start with "E"
+   enum myEnum{}; //RN6 bug
+   ^
+BlackList/match.cpp:6:4: note: [sas.CodingConventions.ROOT.RN6] RN6: Enumerations names must start with "E"
+BlackList/match.cpp:10:4: warning: [sas.CodingConventions.ROOT.RN3] RN3: Typedefs and aliases names must end with a "_t"
+   typedef int time;  // RN3 bug
+   ^
+BlackList/match.cpp:10:4: note: [sas.CodingConventions.ROOT.RN3] RN3: Typedefs and aliases names must end with a "_t"
+BlackList/match.cpp:13:4: warning: [sas.CodingConventions.ROOT.RN6] RN6: Enumerations names must start with "E"
+   enum myEnum{}; //RN6 bug
+   ^
+BlackList/match.cpp:13:4: note: [sas.CodingConventions.ROOT.RN6] RN6: Enumerations names must start with "E"
+3 warnings generated.

--- a/test/BWList/Struct/WhiteList/match.cpp
+++ b/test/BWList/Struct/WhiteList/match.cpp
@@ -1,0 +1,14 @@
+struct TApple
+{
+   typedef int time;  // RN3 bug
+   typedef int time_t;
+   enum EmyEnum{};
+   enum myEnum{}; //RN6 bug
+};
+struct TBoy
+{
+   typedef int time;  // RN3 bug
+   typedef int time_t;
+   enum EmyEnum{};
+   enum myEnum{}; //RN6 bug
+};

--- a/test/BWList/Struct/WhiteList/match.ref
+++ b/test/BWList/Struct/WhiteList/match.ref
@@ -1,0 +1,13 @@
+WhiteList/match.cpp:3:4: warning: [sas.CodingConventions.ROOT.RN3] RN3: Typedefs and aliases names must end with a "_t"
+   typedef int time;  // RN3 bug
+   ^
+WhiteList/match.cpp:3:4: note: [sas.CodingConventions.ROOT.RN3] RN3: Typedefs and aliases names must end with a "_t"
+WhiteList/match.cpp:10:4: warning: [sas.CodingConventions.ROOT.RN3] RN3: Typedefs and aliases names must end with a "_t"
+   typedef int time;  // RN3 bug
+   ^
+WhiteList/match.cpp:10:4: note: [sas.CodingConventions.ROOT.RN3] RN3: Typedefs and aliases names must end with a "_t"
+WhiteList/match.cpp:13:4: warning: [sas.CodingConventions.ROOT.RN6] RN6: Enumerations names must start with "E"
+   enum myEnum{}; //RN6 bug
+   ^
+WhiteList/match.cpp:13:4: note: [sas.CodingConventions.ROOT.RN6] RN6: Enumerations names must start with "E"
+3 warnings generated.

--- a/test/CodingConventions/General/std_printouts.cpp
+++ b/test/CodingConventions/General/std_printouts.cpp
@@ -1,0 +1,9 @@
+#include <iostream>
+#include "stdio.h"
+
+void func()
+{
+   std::cout<<"a";
+   std::cerr<<"b";
+   printf("%d",10);
+}

--- a/test/CodingConventions/General/std_printouts.ref
+++ b/test/CodingConventions/General/std_printouts.ref
@@ -1,0 +1,19 @@
+CodingConventions/General/std_printouts.cpp:6:4: warning: [sas.CodingConventions.General.StdPrintouts] Big software systems always come with an advanced logging infrastructure. The usage of printouts may be considered an issue
+   std::cout<<"a";
+   ^~~~~~~~~~~~~~
+CodingConventions/General/std_printouts.cpp:6:4: note: [sas.CodingConventions.General.StdPrintouts] Big software systems always come with an advanced logging infrastructure. The usage of printouts may be considered an issue
+   std::cout<<"a";
+   ^~~~~~~~~~~~~~
+CodingConventions/General/std_printouts.cpp:7:4: warning: [sas.CodingConventions.General.StdPrintouts] Big software systems always come with an advanced logging infrastructure. The usage of printouts may be considered an issue
+   std::cerr<<"b";
+   ^~~~~~~~~~~~~~
+CodingConventions/General/std_printouts.cpp:7:4: note: [sas.CodingConventions.General.StdPrintouts] Big software systems always come with an advanced logging infrastructure. The usage of printouts may be considered an issue
+   std::cerr<<"b";
+   ^~~~~~~~~~~~~~
+CodingConventions/General/std_printouts.cpp:8:4: warning: [sas.CodingConventions.General.StdPrintouts] Big software systems always come with an advanced logging infrastructure. The usage of printouts may be considered an issue
+   printf("%d",10);
+   ^~~~~~~~~~~~~~~
+CodingConventions/General/std_printouts.cpp:8:4: note: [sas.CodingConventions.General.StdPrintouts] Big software systems always come with an advanced logging infrastructure. The usage of printouts may be considered an issue
+   printf("%d",10);
+   ^~~~~~~~~~~~~~~
+3 warnings generated.

--- a/test/CodingConventions/General/using_namespace.ref
+++ b/test/CodingConventions/General/using_namespace.ref
@@ -1,14 +1,14 @@
-In file included from /test/CodingConventions/General/using_namespace.cpp:1:
-/test/CodingConventions/General/using_namespace.h:1:17: warning: using directive refers to implicitly-defined namespace 'std'
+In file included from CodingConventions/General/using_namespace.cpp:1:
+CodingConventions/General/using_namespace.h:1:17: warning: using directive refers to implicitly-defined namespace 'std'
 using namespace std; //bug
                 ^
-/test/CodingConventions/General/using_namespace.h:1:1: warning: [sas.CodingConventions.General.NoUsingNamespaceInHeaders] Detected usage of 'using namespac ' in a header
+CodingConventions/General/using_namespace.h:1:1: warning: [sas.CodingConventions.General.NoUsingNamespaceInHeaders] Detected usage of 'using namespac ' in a header
 using namespace std; //bug
 ^
-/test/CodingConventions/General/using_namespace.h:1:1: note: [sas.CodingConventions.General.NoUsingNamespaceInHeaders] Detected usage of 'using namespac ' in a header
+CodingConventions/General/using_namespace.h:1:1: note: [sas.CodingConventions.General.NoUsingNamespaceInHeaders] Detected usage of 'using namespac ' in a header
 2 warnings generated.
-In file included from /test/CodingConventions/General/using_namespace.cpp:1:
-/test/CodingConventions/General/using_namespace.h:1:17: warning: using directive refers to implicitly-defined namespace 'std'
+In file included from CodingConventions/General/using_namespace.cpp:1:
+CodingConventions/General/using_namespace.h:1:17: warning: using directive refers to implicitly-defined namespace 'std'
 using namespace std; //bug
                 ^
 1 warning generated.

--- a/test/CodingConventions/ROOT/RN10.ref
+++ b/test/CodingConventions/ROOT/RN10.ref
@@ -1,5 +1,5 @@
-/test/CodingConventions/ROOT/RN10.cpp:2:1: warning: [sas.CodingConventions.ROOT.RN10] RN10: The names of static global variables must begin with "g"
+CodingConventions/ROOT/RN10.cpp:2:1: warning: [sas.CodingConventions.ROOT.RN10] RN10: The names of static global variables must begin with "g"
 static int WrongName = 3;
 ^
-/test/CodingConventions/ROOT/RN10.cpp:2:1: note: [sas.CodingConventions.ROOT.RN10] RN10: The names of static global variables must begin with "g"
+CodingConventions/ROOT/RN10.cpp:2:1: note: [sas.CodingConventions.ROOT.RN10] RN10: The names of static global variables must begin with "g"
 1 warning generated.

--- a/test/CodingConventions/ROOT/RN11.ref
+++ b/test/CodingConventions/ROOT/RN11.ref
@@ -1,5 +1,5 @@
-/test/CodingConventions/ROOT/RN11.cpp:4:4: warning: [sas.CodingConventions.ROOT.RN11] RN11: The names of static data members must begin with "fg"
+CodingConventions/ROOT/RN11.cpp:4:4: warning: [sas.CodingConventions.ROOT.RN11] RN11: The names of static data members must begin with "fg"
    static int fWrongName;
    ^
-/test/CodingConventions/ROOT/RN11.cpp:4:4: note: [sas.CodingConventions.ROOT.RN11] RN11: The names of static data members must begin with "fg"
+CodingConventions/ROOT/RN11.cpp:4:4: note: [sas.CodingConventions.ROOT.RN11] RN11: The names of static data members must begin with "fg"
 1 warning generated.

--- a/test/CodingConventions/ROOT/RN12.ref
+++ b/test/CodingConventions/ROOT/RN12.ref
@@ -1,5 +1,5 @@
-/test/CodingConventions/ROOT/RN12.cpp:4:4: warning: [sas.CodingConventions.ROOT.RN12] RN12: The names local variables must start with a lowercase letter
+CodingConventions/ROOT/RN12.cpp:4:4: warning: [sas.CodingConventions.ROOT.RN12] RN12: The names local variables must start with a lowercase letter
    int IncorrectName = 0;
    ^
-/test/CodingConventions/ROOT/RN12.cpp:4:4: note: [sas.CodingConventions.ROOT.RN12] RN12: The names local variables must start with a lowercase letter
+CodingConventions/ROOT/RN12.cpp:4:4: note: [sas.CodingConventions.ROOT.RN12] RN12: The names local variables must start with a lowercase letter
 1 warning generated.

--- a/test/CodingConventions/ROOT/RN3.ref
+++ b/test/CodingConventions/ROOT/RN3.ref
@@ -1,5 +1,5 @@
-/test/CodingConventions/ROOT/RN3.cpp:2:1: warning: [sas.CodingConventions.ROOT.RN3] RN3: Typedefs and aliases names must end with a "_t"
+CodingConventions/ROOT/RN3.cpp:2:1: warning: [sas.CodingConventions.ROOT.RN3] RN3: Typedefs and aliases names must end with a "_t"
 typedef int time;  // bug
 ^
-/test/CodingConventions/ROOT/RN3.cpp:2:1: note: [sas.CodingConventions.ROOT.RN3] RN3: Typedefs and aliases names must end with a "_t"
+CodingConventions/ROOT/RN3.cpp:2:1: note: [sas.CodingConventions.ROOT.RN3] RN3: Typedefs and aliases names must end with a "_t"
 1 warning generated.

--- a/test/CodingConventions/ROOT/RN4.ref
+++ b/test/CodingConventions/ROOT/RN4.ref
@@ -1,9 +1,9 @@
-/test/CodingConventions/ROOT/RN4.cpp:3:1: warning: [sas.CodingConventions.ROOT.RN4] RN4: Ill formed class/struct name. The first letter must be a "T", the second uppercase and the third lowercase
+CodingConventions/ROOT/RN4.cpp:3:1: warning: [sas.CodingConventions.ROOT.RN4] RN4: Ill formed class/struct name. The first letter must be a "T", the second uppercase and the third lowercase
 class Tyourclass{}; //bug
 ^
-/test/CodingConventions/ROOT/RN4.cpp:3:1: note: [sas.CodingConventions.ROOT.RN4] RN4: Ill formed class/struct name. The first letter must be a "T", the second uppercase and the third lowercase
-/test/CodingConventions/ROOT/RN4.cpp:4:1: warning: [sas.CodingConventions.ROOT.RN4] RN4: Ill formed class/struct name. The first letter must be a "T", the second uppercase and the third lowercase
+CodingConventions/ROOT/RN4.cpp:3:1: note: [sas.CodingConventions.ROOT.RN4] RN4: Ill formed class/struct name. The first letter must be a "T", the second uppercase and the third lowercase
+CodingConventions/ROOT/RN4.cpp:4:1: warning: [sas.CodingConventions.ROOT.RN4] RN4: Ill formed class/struct name. The first letter must be a "T", the second uppercase and the third lowercase
 class myClass{}; //bug
 ^
-/test/CodingConventions/ROOT/RN4.cpp:4:1: note: [sas.CodingConventions.ROOT.RN4] RN4: Ill formed class/struct name. The first letter must be a "T", the second uppercase and the third lowercase
+CodingConventions/ROOT/RN4.cpp:4:1: note: [sas.CodingConventions.ROOT.RN4] RN4: Ill formed class/struct name. The first letter must be a "T", the second uppercase and the third lowercase
 2 warnings generated.

--- a/test/CodingConventions/ROOT/RN6.ref
+++ b/test/CodingConventions/ROOT/RN6.ref
@@ -1,5 +1,5 @@
-/test/CodingConventions/ROOT/RN6.cpp:3:1: warning: [sas.CodingConventions.ROOT.RN6] RN6: Enumerations names must start with "E"
+CodingConventions/ROOT/RN6.cpp:3:1: warning: [sas.CodingConventions.ROOT.RN6] RN6: Enumerations names must start with "E"
 enum myEnum{};
 ^
-/test/CodingConventions/ROOT/RN6.cpp:3:1: note: [sas.CodingConventions.ROOT.RN6] RN6: Enumerations names must start with "E"
+CodingConventions/ROOT/RN6.cpp:3:1: note: [sas.CodingConventions.ROOT.RN6] RN6: Enumerations names must start with "E"
 1 warning generated.

--- a/test/CodingConventions/ROOT/RN9.ref
+++ b/test/CodingConventions/ROOT/RN9.ref
@@ -1,5 +1,5 @@
-/test/CodingConventions/ROOT/RN9.cpp:2:1: warning: [sas.CodingConventions.ROOT.RN9] RN9Functions: Ill formed function name. The first letter must be capital letter
+CodingConventions/ROOT/RN9.cpp:2:1: warning: [sas.CodingConventions.ROOT.RN9] RN9Functions: Ill formed function name. The first letter must be capital letter
 int fun1() //bug
 ^
-/test/CodingConventions/ROOT/RN9.cpp:2:1: note: [sas.CodingConventions.ROOT.RN9] RN9Functions: Ill formed function name. The first letter must be capital letter
+CodingConventions/ROOT/RN9.cpp:2:1: note: [sas.CodingConventions.ROOT.RN9] RN9Functions: Ill formed function name. The first letter must be capital letter
 1 warning generated.

--- a/test/CodingConventions/ROOT/ptr_cast_win.ref
+++ b/test/CodingConventions/ROOT/ptr_cast_win.ref
@@ -1,7 +1,7 @@
-/test/CodingConventions/ROOT/ptr_cast_win.cpp:5:13: warning: [sas.CodingConventions.ROOT.PtrCastWinChecker] Casting pointers to integer types which are not (unsigned) long long (in this case a long) is wrong on Windows 64 bits. 
+CodingConventions/ROOT/ptr_cast_win.cpp:5:13: warning: [sas.CodingConventions.ROOT.PtrCastWinChecker] Casting pointers to integer types which are not (unsigned) long long (in this case a long) is wrong on Windows 64 bits. 
    a =(long)p;
       ~~~~~~^
-/test/CodingConventions/ROOT/ptr_cast_win.cpp:5:13: note: [sas.CodingConventions.ROOT.PtrCastWinChecker] Casting pointers to integer types which are not (unsigned) long long (in this case a long) is wrong on Windows 64 bits. 
+CodingConventions/ROOT/ptr_cast_win.cpp:5:13: note: [sas.CodingConventions.ROOT.PtrCastWinChecker] Casting pointers to integer types which are not (unsigned) long long (in this case a long) is wrong on Windows 64 bits. 
    a =(long)p;
       ~~~~~~^
 1 warning generated.

--- a/test/Example/varname.ref
+++ b/test/Example/varname.ref
@@ -1,5 +1,5 @@
-/test/Example/varname.cpp:8:3: warning: [sas.Example.Varname] Variable name doesn't begin with an upper case letter
+Example/varname.cpp:8:3: warning: [sas.Example.Varname] Variable name doesn't begin with an upper case letter
   int variable; // bug: doesn't begin with uppercase
   ^
-/test/Example/varname.cpp:8:3: note: [sas.Example.Varname] Variable name doesn't begin with an upper case letter
+Example/varname.cpp:8:3: note: [sas.Example.Varname] Variable name doesn't begin with an upper case letter
 1 warning generated.

--- a/test/Performance/arg_size.ref
+++ b/test/Performance/arg_size.ref
@@ -1,5 +1,5 @@
-/test/Performance/arg_size.cpp:11:4: warning: [sas.Performance.ArgSizeChecker] Function parameter passed by value with size of parameter '320' bits > max size '128' bits parameter type 'struct SuperLong' function 'FuncA' class 'TDemo'
+Performance/arg_size.cpp:11:4: warning: [sas.Performance.ArgSizeChecker] Function parameter passed by value with size of parameter '320' bits > max size '128' bits parameter type 'struct SuperLong' function 'FuncA' class 'TDemo'
    int FuncA (SuperLong arg){return 0;}
    ^
-/test/Performance/arg_size.cpp:11:4: note: [sas.Performance.ArgSizeChecker] Function parameter passed by value with size of parameter '320' bits > max size '128' bits parameter type 'struct SuperLong' function 'FuncA' class 'TDemo'
+Performance/arg_size.cpp:11:4: note: [sas.Performance.ArgSizeChecker] Function parameter passed by value with size of parameter '320' bits > max size '128' bits parameter type 'struct SuperLong' function 'FuncA' class 'TDemo'
 1 warning generated.

--- a/test/Performance/finite_math.ref
+++ b/test/Performance/finite_math.ref
@@ -1,14 +1,14 @@
-/test/Performance/finite_math.cpp:14:7: warning: [sas.Performance.FiniteMathChecker] The function isnan/isinf does not work when fast-math is enabled. Please check the bits of the floating point number instead
+Performance/finite_math.cpp:14:7: warning: [sas.Performance.FiniteMathChecker] The function isnan/isinf does not work when fast-math is enabled. Please check the bits of the floating point number instead
   if (isnan(Var)) { // bug: isnan used
       ^
 /usr/include/math.h:255:9: note: expanded from macro 'isnan'
       ? __isnanf (x)                                                          \
         ^
-/test/Performance/finite_math.cpp:14:7: note: '?' condition is true
+Performance/finite_math.cpp:14:7: note: '?' condition is true
 /usr/include/math.h:254:7: note: expanded from macro 'isnan'
      (sizeof (x) == sizeof (float)                                            \
       ^
-/test/Performance/finite_math.cpp:14:7: note: [sas.Performance.FiniteMathChecker] The function isnan/isinf does not work when fast-math is enabled. Please check the bits of the floating point number instead
+Performance/finite_math.cpp:14:7: note: [sas.Performance.FiniteMathChecker] The function isnan/isinf does not work when fast-math is enabled. Please check the bits of the floating point number instead
   if (isnan(Var)) { // bug: isnan used
       ^~~~~~~~~~
 /usr/include/math.h:255:9: note: expanded from macro 'isnan'

--- a/test/ThreadSafety/const_cast.ref
+++ b/test/ThreadSafety/const_cast.ref
@@ -1,13 +1,13 @@
-/test/ThreadSafety/const_cast.cpp:14:36: warning: [sas.ThreadSafety.ConstCastChecker] const_cast was used, this may result in thread-unsafe code
+ThreadSafety/const_cast.cpp:14:36: warning: [sas.ThreadSafety.ConstCastChecker] const_cast was used, this may result in thread-unsafe code
   string& r1 = const_cast<string&>(r_const); // bug
                ~~~~~~~~~~~~~~~~~~~~^~~~~~~~
-/test/ThreadSafety/const_cast.cpp:14:36: note: [sas.ThreadSafety.ConstCastChecker] const_cast was used, this may result in thread-unsafe code
+ThreadSafety/const_cast.cpp:14:36: note: [sas.ThreadSafety.ConstCastChecker] const_cast was used, this may result in thread-unsafe code
   string& r1 = const_cast<string&>(r_const); // bug
                ~~~~~~~~~~~~~~~~~~~~^~~~~~~~
-/test/ThreadSafety/const_cast.cpp:15:36: warning: [sas.ThreadSafety.ConstCastChecker] const_cast was used, this may result in thread-unsafe code
+ThreadSafety/const_cast.cpp:15:36: warning: [sas.ThreadSafety.ConstCastChecker] const_cast was used, this may result in thread-unsafe code
   string& r2 = const_cast<string&>(r_const); // bug
                ~~~~~~~~~~~~~~~~~~~~^~~~~~~~
-/test/ThreadSafety/const_cast.cpp:15:36: note: [sas.ThreadSafety.ConstCastChecker] const_cast was used, this may result in thread-unsafe code
+ThreadSafety/const_cast.cpp:15:36: note: [sas.ThreadSafety.ConstCastChecker] const_cast was used, this may result in thread-unsafe code
   string& r2 = const_cast<string&>(r_const); // bug
                ~~~~~~~~~~~~~~~~~~~~^~~~~~~~
 2 warnings generated.

--- a/test/ThreadSafety/const_cast_away.ref
+++ b/test/ThreadSafety/const_cast_away.ref
@@ -1,13 +1,13 @@
-/test/ThreadSafety/const_cast_away.cpp:14:41: warning: [sas.ThreadSafety.ConstCastAwayChecker]const qualifier was removed via a cast, this may result in thread-unsafe code
+ThreadSafety/const_cast_away.cpp:14:41: warning: [sas.ThreadSafety.ConstCastAwayChecker]const qualifier was removed via a cast, this may result in thread-unsafe code
     std::string & r = (std::string &) ( r_const );
                       ~~~~~~~~~~~~~~~~~~^~~~~~~~~
-/test/ThreadSafety/const_cast_away.cpp:14:41: note: [sas.ThreadSafety.ConstCastAwayChecker]const qualifier was removed via a cast, this may result in thread-unsafe code
+ThreadSafety/const_cast_away.cpp:14:41: note: [sas.ThreadSafety.ConstCastAwayChecker]const qualifier was removed via a cast, this may result in thread-unsafe code
     std::string & r = (std::string &) ( r_const );
                       ~~~~~~~~~~~~~~~~~~^~~~~~~~~
-/test/ThreadSafety/const_cast_away.cpp:15:36: warning: [sas.ThreadSafety.ConstCastAwayChecker]const qualifier was removed via a cast, this may result in thread-unsafe code
+ThreadSafety/const_cast_away.cpp:15:36: warning: [sas.ThreadSafety.ConstCastAwayChecker]const qualifier was removed via a cast, this may result in thread-unsafe code
         std::string * p = (std::string *) ( p_const );
                           ~~~~~~~~~~~~~~~~^~~~~~~~~~~
-/test/ThreadSafety/const_cast_away.cpp:15:36: note: [sas.ThreadSafety.ConstCastAwayChecker]const qualifier was removed via a cast, this may result in thread-unsafe code
+ThreadSafety/const_cast_away.cpp:15:36: note: [sas.ThreadSafety.ConstCastAwayChecker]const qualifier was removed via a cast, this may result in thread-unsafe code
         std::string * p = (std::string *) ( p_const );
                           ~~~~~~~~~~~~~~~~^~~~~~~~~~~
 2 warnings generated.

--- a/test/ThreadSafety/global_static.ref
+++ b/test/ThreadSafety/global_static.ref
@@ -1,9 +1,9 @@
-/test/ThreadSafety/global_static.cpp:13:1: warning: [sas.ThreadSafety.GlobalStaticChecker] Non-const variable 'g_static' is static and might be thread-unsafe
+ThreadSafety/global_static.cpp:13:1: warning: [sas.ThreadSafety.GlobalStaticChecker] Non-const variable 'g_static' is static and might be thread-unsafe
 static int g_static;
 ^
-/test/ThreadSafety/global_static.cpp:13:1: note: [sas.ThreadSafety.GlobalStaticChecker] Non-const variable 'g_static' is static and might be thread-unsafe
-/test/ThreadSafety/global_static.cpp:14:1: warning: [sas.ThreadSafety.GlobalStaticChecker] Non-const variable 'g_ptr_static' is static and might be thread-unsafe
+ThreadSafety/global_static.cpp:13:1: note: [sas.ThreadSafety.GlobalStaticChecker] Non-const variable 'g_static' is static and might be thread-unsafe
+ThreadSafety/global_static.cpp:14:1: warning: [sas.ThreadSafety.GlobalStaticChecker] Non-const variable 'g_ptr_static' is static and might be thread-unsafe
 static int * g_ptr_static = &g_static;
 ^
-/test/ThreadSafety/global_static.cpp:14:1: note: [sas.ThreadSafety.GlobalStaticChecker] Non-const variable 'g_ptr_static' is static and might be thread-unsafe
+ThreadSafety/global_static.cpp:14:1: note: [sas.ThreadSafety.GlobalStaticChecker] Non-const variable 'g_ptr_static' is static and might be thread-unsafe
 2 warnings generated.

--- a/test/ThreadSafety/mutable_member.ref
+++ b/test/ThreadSafety/mutable_member.ref
@@ -1,5 +1,5 @@
-/test/ThreadSafety/mutable_member.cpp:3:4: warning: [sas.ThreadSafety.MutableMemberChecker] Mutable member'p' in class, might be thread-unsafe when accessing via a const handle
+ThreadSafety/mutable_member.cpp:3:4: warning: [sas.ThreadSafety.MutableMemberChecker] Mutable member'p' in class, might be thread-unsafe when accessing via a const handle
    mutable int p;
    ^
-/test/ThreadSafety/mutable_member.cpp:3:4: note: [sas.ThreadSafety.MutableMemberChecker] Mutable member'p' in class, might be thread-unsafe when accessing via a const handle
+ThreadSafety/mutable_member.cpp:3:4: note: [sas.ThreadSafety.MutableMemberChecker] Mutable member'p' in class, might be thread-unsafe when accessing via a const handle
 1 warning generated.

--- a/test/ThreadSafety/static_local.ref
+++ b/test/ThreadSafety/static_local.ref
@@ -1,17 +1,17 @@
-/test/ThreadSafety/static_local.cpp:10:9: warning: [sas.ThreadSafety.StaticLocalChecker] Non-const variable 'evilStaticLocal' is local static and might be thread-unsafe
+ThreadSafety/static_local.cpp:10:9: warning: [sas.ThreadSafety.StaticLocalChecker] Non-const variable 'evilStaticLocal' is local static and might be thread-unsafe
         static int evilStaticLocal = 0;
         ^
-/test/ThreadSafety/static_local.cpp:10:9: note: [sas.ThreadSafety.StaticLocalChecker] Non-const variable 'evilStaticLocal' is local static and might be thread-unsafe
-/test/ThreadSafety/static_local.cpp:11:9: warning: [sas.ThreadSafety.StaticLocalChecker] Non-const variable 'intRef' is local static and might be thread-unsafe
+ThreadSafety/static_local.cpp:10:9: note: [sas.ThreadSafety.StaticLocalChecker] Non-const variable 'evilStaticLocal' is local static and might be thread-unsafe
+ThreadSafety/static_local.cpp:11:9: warning: [sas.ThreadSafety.StaticLocalChecker] Non-const variable 'intRef' is local static and might be thread-unsafe
         static int & intRef = evilStaticLocal;
         ^
-/test/ThreadSafety/static_local.cpp:11:9: note: [sas.ThreadSafety.StaticLocalChecker] Non-const variable 'intRef' is local static and might be thread-unsafe
-/test/ThreadSafety/static_local.cpp:12:2: warning: [sas.ThreadSafety.StaticLocalChecker] Non-const variable 'intPtr' is local static and might be thread-unsafe
+ThreadSafety/static_local.cpp:11:9: note: [sas.ThreadSafety.StaticLocalChecker] Non-const variable 'intRef' is local static and might be thread-unsafe
+ThreadSafety/static_local.cpp:12:2: warning: [sas.ThreadSafety.StaticLocalChecker] Non-const variable 'intPtr' is local static and might be thread-unsafe
         static int * intPtr = & evilStaticLocal;
         ^
-/test/ThreadSafety/static_local.cpp:12:2: note: [sas.ThreadSafety.StaticLocalChecker] Non-const variable 'intPtr' is local static and might be thread-unsafe
-/test/ThreadSafety/static_local.cpp:20:9: warning: [sas.ThreadSafety.StaticLocalChecker] Non-const variable 'threadLocal' is local static and might be thread-unsafe
+ThreadSafety/static_local.cpp:12:2: note: [sas.ThreadSafety.StaticLocalChecker] Non-const variable 'intPtr' is local static and might be thread-unsafe
+ThreadSafety/static_local.cpp:20:9: warning: [sas.ThreadSafety.StaticLocalChecker] Non-const variable 'threadLocal' is local static and might be thread-unsafe
         static int threadLocal = 0;
         ^
-/test/ThreadSafety/static_local.cpp:20:9: note: [sas.ThreadSafety.StaticLocalChecker] Non-const variable 'threadLocal' is local static and might be thread-unsafe
+ThreadSafety/static_local.cpp:20:9: note: [sas.ThreadSafety.StaticLocalChecker] Non-const variable 'threadLocal' is local static and might be thread-unsafe
 4 warnings generated.


### PR DESCRIPTION
Hi Danilo,

This is the patch for path matching black/white list mechanism. 

- The Configuration file(**.sas.yaml**) is under the project root directory('test' dir when testing). 
- We have some rules in that configuration file, each rule is a triple tuple for criteria and checkers and B/W switch
- At the time the filter work, we firstly check file_path, if path matching, we will check the other criteria. When all 4 criteria matched, we then check the B/W switch and checkers. 
- If the rules is blacklist, and current checker is in the checkers list, we disable the current checker.
- If the rules is whitelist, and current checker is not in the checkers list, we disable the current checker.
- Else or by the default(unsuccessful parsing, no .sas.yaml file found....etc) we always fire the checker.
- I used *fnmatch.h* for Path matching , std::regex for Struct/Class/Namespace matching, prefix substring matching for checker matching.  
- libyaml-cpp is required for parsing; libyaml-cpp is built on boost. So I add two find*.cmake into cmake directory.(Install the libraries by 'sudo apt-get install libyaml-cpp-dev libboost-all-dev')


For every B/W list rule:
- We have 4 criteria for coding block matching, which is **Path, Namespace, Struct and Class**
- We have 1 switch for Black/White switching
- We have to specifiy the checkers enabled/disabled under that rule

A simple  .sas.yaml is like the following:
```
CONFIGURATION:
  - FILE_PATH: ["BlackWhiteList/WhiteList/*.cpp"]
    CHECKER: ["sas.CodingConventions.ROOT.RN3", "sas.CodingConventions.ROOT.RN4"]
    B/W: W
  - FILE_PATH: ["BlackWhiteList/BlackList/*.cpp"]
    CHECKER: ["sas.CodingConventions.ROOT.RN3", "sas.CodingConventions.ROOT.RN4"]
    B/W: B
```

We have 6 tests for now, and for the future we will add more tests to cover all the cases in B/W filter mechanism.
