### PR TITLE
Misc fixes and cleanups

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -89,6 +89,15 @@ macro(add_clang_plugin name)
       target_link_libraries( ${name} ${user_lib} )
    endforeach()
 
+   target_link_libraries( ${name} llvmSupport )
+   target_link_libraries( ${name} clangAST)
+   target_link_libraries( ${name} clangBasic)
+   target_link_libraries( ${name} clangAnalysis)
+   target_link_libraries( ${name} clangStaticAnalyzerCheckers)
+   target_link_libraries( ${name} clangLex)
+   target_link_libraries( ${name} clangStaticAnalyzerCore)
+   target_link_libraries( ${name} ncurses)
+
    install(TARGETS ${name} DESTINATION lib)
 
    set_target_properties( ${name} PROPERTIES


### PR DESCRIPTION
See comments in the commits. I'm building using clang 3.6 on mac.

It would also be nice to have a `make install` target which puts the plugin somewhere in CMAKE_INSTALL_PREFIX.