### PR TITLE
Link LLVMSupport instead of llvmSupport

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -89,7 +89,7 @@ macro(add_clang_plugin name)
       target_link_libraries( ${name} ${user_lib} )
    endforeach()
 
-   target_link_libraries( ${name} llvmSupport )
+   target_link_libraries( ${name} LLVMSupport )
    target_link_libraries( ${name} clangAST)
    target_link_libraries( ${name} clangBasic)
    target_link_libraries( ${name} clangAnalysis)


### PR DESCRIPTION
Hello @dpiparo, I have noticed that library `llvmSupport` is linked, however in `FindLLVM.cmake` the library `LLVMSupport` is looked for. On my test system (a Docker container with Ubuntu 14.04) the library is called `libLLVMSupport.a`, therefore the CMake bootstrapping succeeds, whereas linking fails. This PR solves my problem.

Not sure it won't break elsewhere. In principle if the library can have two different names, a more elaborate `FindLLVM.cmake` should be provided. I can help with that if needed :-)