### PR TITLE
Adapt to new LLVM API

### DIFF
--- a/src/IncludeDumper.h
+++ b/src/IncludeDumper.h
@@ -49,7 +49,7 @@ class InclusionDump : public clang::ASTConsumer {
 class InclusionDumpAction : public clang::PluginASTAction {
   public:
     InclusionDumpAction() : m_dirMask("") {}
-    bool ParseArgs(const clang::CompilerInstance &CI, const std::vector<std::string>& args);
+    virtual bool ParseArgs(const clang::CompilerInstance &CI, const std::vector<std::string>& args) override;
 
   protected:
     std::unique_ptr<clang::ASTConsumer> CreateASTConsumer(clang::CompilerInstance &CI,

--- a/src/Performance/FiniteMathChecker.cpp
+++ b/src/Performance/FiniteMathChecker.cpp
@@ -21,7 +21,7 @@ namespace sas {
              !II->isStr("__isnan") && !II->isStr("__isinf") &&
              !II->isStr("__isnanf") && !II->isStr("__isinff")) return;
 
-         clang::ento::ExplodedNode *N = C.generateSink();
+         clang::ento::ExplodedNode *N = C.generateErrorNode();
          if (!N) return;
 
          const char* msg = "[sas.Performance.FiniteMathChecker] The function isnan/isinf does not work when fast-math is enabled. Please check the bits of the floating point number instead.";

--- a/src/SasChecker.h
+++ b/src/SasChecker.h
@@ -93,9 +93,9 @@ public:
       if(bw.isDisabled()) return;
       if (auto errorNode = C.addTransition()) {
          auto bt = new clang::ento::BugType(this, Traits::BugName, Traits::BugCategory);
-         auto br = new clang::ento::BugReport(*bt, msg, errorNode);
+         auto br = llvm::make_unique<clang::ento::BugReport>(*bt, msg, errorNode);
          br->addRange(E->getSourceRange());
-         C.emitReport(br);
+         C.emitReport(std::move(br));
       }
    }
 };

--- a/src/jsonxx.h
+++ b/src/jsonxx.h
@@ -200,24 +200,24 @@ class Value {
     type_ = BOOL_;
     bool_value_ = b;
   }
-#define $number(TYPE) \
+#define _number(TYPE) \
   void import( const TYPE &n ) { \
     reset(); \
     type_ = NUMBER_; \
     number_value_ = static_cast<long double>(n); \
   }
-  $number( char )
-  $number( int )
-  $number( long )
-  $number( long long )
-  $number( unsigned char )
-  $number( unsigned int )
-  $number( unsigned long )
-  $number( unsigned long long )
-  $number( float )
-  $number( double )
-  $number( long double )
-#undef $number
+  _number( char )
+  _number( int )
+  _number( long )
+  _number( long long )
+  _number( unsigned char )
+  _number( unsigned int )
+  _number( unsigned long )
+  _number( unsigned long long )
+  _number( float )
+  _number( double )
+  _number( long double )
+#undef _number
 #if JSONXX_COMPILER_HAS_CXX11 > 0
   void import( const std::nullptr_t & ) {
     reset();
@@ -382,7 +382,7 @@ const T& Object::get(const std::string& key, const typename identity<T>::type& d
     return default_value;
   }
 }
-    
+
 template<>
 inline bool Value::is<Value>() const {
     return true;
@@ -417,12 +417,12 @@ template<>
 inline bool Value::is<Object>() const {
   return type_ == OBJECT_;
 }
-    
+
 template<>
 inline Value& Value::get<Value>() {
     return *this;
 }
-    
+
 template<>
 inline const Value& Value::get<Value>() const {
     return *this;


### PR DESCRIPTION
Small changes necessary to use SAS with clang version >= 2.7. Fixes #42.